### PR TITLE
Fixing NPE when lookup resources under Linux

### DIFF
--- a/test/org/beanio/parser/bean/BeanParserTest.java
+++ b/test/org/beanio/parser/bean/BeanParserTest.java
@@ -83,7 +83,7 @@ public class BeanParserTest extends ParserTest {
     @Test
     public void testFixedLengthAndOptionalFields() {
         BeanReader in = factory.createReader("w3", new InputStreamReader(
-            getClass().getResourceAsStream("w3_fixedlength.txt")));
+            getClass().getResourceAsStream("w3_fixedLength.txt")));
         
         try {
             Widget w = (Widget) in.read();


### PR DESCRIPTION
This occurs because Linux lookup files using case-sensitive matcher.
