### PR TITLE
Using AutoCloseable to allow us to use try-with-resources statement

### DIFF
--- a/src/org/beanio/BeanReader.java
+++ b/src/org/beanio/BeanReader.java
@@ -15,6 +15,7 @@
  */
 package org.beanio;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 import org.beanio.internal.util.Debuggable;
@@ -28,7 +29,7 @@ import org.beanio.internal.util.Debuggable;
  * @since 1.0
  * @see StreamFactory
  */
-public interface BeanReader extends Debuggable {
+public interface BeanReader extends Debuggable, Closeable {
 
 	/**
 	 * Reads a single bean from the input stream.  If the end of the stream is
@@ -108,7 +109,8 @@ public interface BeanReader extends Debuggable {
 	 * @throws BeanReaderIOException if the underlying input stream throws an
      *   {@link IOException} or this reader was already closed
 	 */
-    public void close() throws BeanReaderIOException;
+    @Override
+	public void close() throws BeanReaderIOException;
 
     /**
      * Sets the error handler to handle exceptions thrown by {@link #read()}.

--- a/src/org/beanio/BeanWriter.java
+++ b/src/org/beanio/BeanWriter.java
@@ -29,7 +29,7 @@ import org.beanio.internal.util.Debuggable;
  * @since 1.0
  * @see StreamFactory
  */
-public interface BeanWriter extends Debuggable {
+public interface BeanWriter extends Debuggable, AutoCloseable {
 
     /**
      * Writes a bean object to this output stream.
@@ -68,6 +68,7 @@ public interface BeanWriter extends Debuggable {
      * @throws BeanWriterIOException if the underlying output stream throws an {@link IOException},
      *   or if this writer is already closed
      */
-    public void close() throws BeanWriterIOException;
+    @Override
+	public void close() throws BeanWriterIOException;
 
 }

--- a/test/org/beanio/StreamFactoryTest.java
+++ b/test/org/beanio/StreamFactoryTest.java
@@ -85,12 +85,8 @@ public class StreamFactoryTest {
         factory.loadResource("org/beanio/mapping.xml");
         
         File file = new File("test/org/beanio/file.txt");
-        BeanReader in = factory.createReader("stream1", file);
-        try {
+        try (BeanReader in = factory.createReader("stream1", file)) {
             while (in.read() != null);
-        }
-        finally {
-            in.close();
         }
     }
     


### PR DESCRIPTION
With this pull request we can use `try-with-resources` statement.

Before changes:

``` java
try {
    BeanReader in = factory.createReader("stream1", file);
    [...]
} finally {
    in.close();
}
```

And now:

``` java
try (BeanReader in = factory.createReader("stream1", file)) {
    [...]
}
```
