### PR TITLE
Changing Closeable to AutoCloseable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,8 +8,7 @@ Changes in version 3.0.0 (TBD)
 * Removed Spring framework support
 * Fixed IOUtil.getResource() to use ClassLoader argument (gc0109)
 * Added support for validating marshalled fields (gc0096)
-* BeanWriter now implements AutoCloseable
-* BeanReader now implements Closeable
+* BeanWriter and BeanReader now implements AutoCloseable
 * Added SegmentBuilder.at(int) method
 
 Changes in version 2.1.0 (2014-09-06)

--- a/src/org/beanio/BeanReader.java
+++ b/src/org/beanio/BeanReader.java
@@ -15,7 +15,6 @@
  */
 package org.beanio;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 import org.beanio.internal.util.Debuggable;
@@ -29,7 +28,7 @@ import org.beanio.internal.util.Debuggable;
  * @since 1.0
  * @see StreamFactory
  */
-public interface BeanReader extends Debuggable, Closeable {
+public interface BeanReader extends Debuggable, AutoCloseable {
 
 	/**
 	 * Reads a single bean from the input stream.  If the end of the stream is


### PR DESCRIPTION
Sorry for my previously commit. `AutoCloseable` is the right interface to inherit `BeanWriter` and BeanReader`.
