### PR TITLE
Using modern Java APIs

### DIFF
--- a/src/org/beanio/BeanReaderErrorHandlerSupport.java
+++ b/src/org/beanio/BeanReaderErrorHandlerSupport.java
@@ -37,6 +37,7 @@ public class BeanReaderErrorHandlerSupport implements BeanReaderErrorHandler {
      * @throws Exception if the BeanReaderException is rethrown or this error
      *   handler throws a new Exception
      */
+    @Override
     public final void handleError(BeanReaderException ex) throws Exception {
         if (ex instanceof InvalidRecordException) {
             invalidRecord((InvalidRecordException)ex);

--- a/src/org/beanio/Marshaller.java
+++ b/src/org/beanio/Marshaller.java
@@ -75,6 +75,7 @@ public interface Marshaller extends Debuggable {
      * @return the record text
      * @throws BeanWriterException if a fatal error occurs
      */
+    @Override
     public String toString() throws BeanWriterException;
     
     /**

--- a/src/org/beanio/builder/CsvParserBuilder.java
+++ b/src/org/beanio/builder/CsvParserBuilder.java
@@ -79,7 +79,7 @@ public class CsvParserBuilder extends ParserBuilder {
     
     @Override
     public BeanConfig<RecordParserFactory> build() {
-        BeanConfig<RecordParserFactory> config = new BeanConfig<RecordParserFactory>();
+        BeanConfig<RecordParserFactory> config = new BeanConfig<>();
         config.setInstance(parser);
         return config;
     }

--- a/src/org/beanio/builder/DelimitedParserBuilder.java
+++ b/src/org/beanio/builder/DelimitedParserBuilder.java
@@ -62,7 +62,7 @@ public class DelimitedParserBuilder extends ParserBuilder {
     
     @Override
     public BeanConfig<RecordParserFactory> build() {
-        BeanConfig<RecordParserFactory> config = new BeanConfig<RecordParserFactory>();
+        BeanConfig<RecordParserFactory> config = new BeanConfig<>();
         config.setInstance(parser);
         return config;
     }

--- a/src/org/beanio/builder/FixedLengthParserBuilder.java
+++ b/src/org/beanio/builder/FixedLengthParserBuilder.java
@@ -66,7 +66,7 @@ public class FixedLengthParserBuilder extends ParserBuilder {
     
     @Override
     public BeanConfig<RecordParserFactory> build() {
-        BeanConfig<RecordParserFactory> config = new BeanConfig<RecordParserFactory>();
+        BeanConfig<RecordParserFactory> config = new BeanConfig<>();
         config.setInstance(parser);
         return config;
     }

--- a/src/org/beanio/builder/SegmentBuilderSupport.java
+++ b/src/org/beanio/builder/SegmentBuilderSupport.java
@@ -27,6 +27,7 @@ public abstract class SegmentBuilderSupport<T extends SegmentBuilderSupport<T>> 
 
     SegmentBuilderSupport() { }
     
+    @Override
     protected abstract SegmentConfig getConfig();
     
     /**

--- a/src/org/beanio/builder/StreamBuilder.java
+++ b/src/org/beanio/builder/StreamBuilder.java
@@ -76,7 +76,7 @@ public class StreamBuilder extends GroupBuilderSupport<StreamBuilder> {
      * @return this
      */
     public StreamBuilder parser(RecordParserFactory parser) {
-        BeanConfig<RecordParserFactory> bc = new BeanConfig<RecordParserFactory>();
+        BeanConfig<RecordParserFactory> bc = new BeanConfig<>();
         bc.setInstance(parser);
         config.setParserFactory(bc);
         return this;

--- a/src/org/beanio/builder/XmlParserBuilder.java
+++ b/src/org/beanio/builder/XmlParserBuilder.java
@@ -70,7 +70,7 @@ public class XmlParserBuilder extends ParserBuilder {
     
     @Override
     public BeanConfig<RecordParserFactory> build() {
-        BeanConfig<RecordParserFactory> config = new BeanConfig<RecordParserFactory>();
+        BeanConfig<RecordParserFactory> config = new BeanConfig<>();
         config.setInstance(parser);
         return config;
     }

--- a/src/org/beanio/internal/DefaultStreamFactory.java
+++ b/src/org/beanio/internal/DefaultStreamFactory.java
@@ -35,7 +35,7 @@ import org.beanio.internal.parser.Stream;
 public class DefaultStreamFactory extends StreamFactory {
 
     private StreamCompiler compiler;
-    private Map<String, Stream> contextMap = new ConcurrentHashMap<String, Stream>();
+    private Map<String, Stream> contextMap = new ConcurrentHashMap<>();
 
     /**
      * Constructs a new <tt>DefaultStreamFactory</tt>.

--- a/src/org/beanio/internal/compiler/ParserFactorySupport.java
+++ b/src/org/beanio/internal/compiler/ParserFactorySupport.java
@@ -76,6 +76,7 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
      * @return the new {@link Stream}
      * @throws BeanIOConfigurationException if the configuration is invalid
      */
+    @Override
     public Stream createStream(StreamConfig config) throws BeanIOConfigurationException {
         if (config.getName() == null) {
             throw new BeanIOConfigurationException("stream name not configured");
@@ -245,6 +246,7 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
         
         // sort arguments by constructor index
         Collections.sort(args, new Comparator<Property>() {
+            @Override
             public int compare(Property o1, Property o2) {
                 return o1.getAccessor().getConstructorArgumentIndex() -
                     o2.getAccessor().getConstructorArgumentIndex();
@@ -1652,6 +1654,7 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
      * @param typeHandlerFactory the <tt>TypeHandlerFactory</tt> to use to
      *   create the stream definition
      */
+    @Override
     public void setTypeHandlerFactory(TypeHandlerFactory typeHandlerFactory) {
         this.typeHandlerFactory = typeHandlerFactory;
     }
@@ -1721,6 +1724,7 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
      * (non-Javadoc)
      * @see org.beanio.factory.ParserFactory#setClassLoader(java.lang.ClassLoader)
      */
+    @Override
     public void setClassLoader(ClassLoader classLoader) {
         this.classLoader = classLoader;
     }

--- a/src/org/beanio/internal/compiler/ParserFactorySupport.java
+++ b/src/org/beanio/internal/compiler/ParserFactorySupport.java
@@ -1527,7 +1527,7 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
             if (config.getComponentType() == ComponentConfig.SEGMENT) {
                 required = config.getMinOccurs() > 0 && !config.isNillable();
             }
-            boolean matchNull = !required && new Integer(0).equals(config.getMinOccurs());
+            boolean matchNull = !required && Integer.valueOf(0).equals(config.getMinOccurs());
             
             CollectionBean collection = new CollectionBean();
             collection.setName(config.getName());
@@ -1538,7 +1538,7 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
         }
         else {
             boolean required = propertyStack.isEmpty();
-            boolean matchNull = !required && new Integer(0).equals(config.getMinOccurs());
+            boolean matchNull = !required && Integer.valueOf(0).equals(config.getMinOccurs());
             
             Bean bean = new Bean();
             bean.setName(config.getName());

--- a/src/org/beanio/internal/compiler/ParserFactorySupport.java
+++ b/src/org/beanio/internal/compiler/ParserFactorySupport.java
@@ -62,8 +62,8 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
     private PropertyAccessorFactory accessorFactory;
     private ClassLoader classLoader;
     
-    private LinkedList<Component> parserStack = new LinkedList<Component>();
-    private LinkedList<Component> propertyStack = new LinkedList<Component>();
+    private LinkedList<Component> parserStack = new LinkedList<>();
+    private LinkedList<Component> propertyStack = new LinkedList<>();
     
     /**
      * Constructs a new <tt>ParserFactory</tt>.
@@ -232,7 +232,7 @@ public abstract class ParserFactorySupport extends ProcessorSupport implements P
             
             if (property.getAccessor().isConstructorArgument()) {
                 if (args == null) {
-                    args = new ArrayList<Property>();
+                    args = new ArrayList<>();
                 }
                 args.add(property);
             }

--- a/src/org/beanio/internal/compiler/Preprocessor.java
+++ b/src/org/beanio/internal/compiler/Preprocessor.java
@@ -50,6 +50,7 @@ public class Preprocessor extends ProcessorSupport {
      * Initializes a stream configuration before its children have been processed.
      * @param stream the stream configuration to process
      */
+    @Override
     protected void initializeStream(StreamConfig stream) throws BeanIOConfigurationException { 
         if (stream.getMinOccurs() == null) {
             stream.setMinOccurs(0);
@@ -68,6 +69,7 @@ public class Preprocessor extends ProcessorSupport {
      * Finalizes a stream configuration after its children have been processed.
      * @param stream the stream configuration to finalize
      */
+    @Override
     protected void finalizeStream(StreamConfig stream) throws BeanIOConfigurationException { 
         finalizeGroup(stream);
         
@@ -78,6 +80,7 @@ public class Preprocessor extends ProcessorSupport {
         
         if (sorted) {
             stream.sort(new Comparator<ComponentConfig>() {
+                @Override
                 public int compare(ComponentConfig c1, ComponentConfig c2) {
                     Integer p1 = getPosition(c1);
                     Integer p2 = getPosition(c2);
@@ -125,6 +128,7 @@ public class Preprocessor extends ProcessorSupport {
      * Initializes a group configuration before its children have been processed.
      * @param group the group configuration to process
      */
+    @Override
     protected void initializeGroup(GroupConfig group) throws BeanIOConfigurationException {
         
         if (group.getMinOccurs() == null) {
@@ -171,6 +175,7 @@ public class Preprocessor extends ProcessorSupport {
      * Finalizes a group configuration after its children have been processed.
      * @param group the group configuration to finalize
      */
+    @Override
     protected void finalizeGroup(GroupConfig group) throws BeanIOConfigurationException {
         
         // order must be set for all group children, or for none of them
@@ -225,6 +230,7 @@ public class Preprocessor extends ProcessorSupport {
      * Initializes a record configuration before its children have been processed.
      * @param record the record configuration to process
      */
+    @Override
     protected void initializeRecord(RecordConfig record) throws BeanIOConfigurationException {
         
         // a record is ignored if a 'class' was not set and the property root is null
@@ -262,6 +268,7 @@ public class Preprocessor extends ProcessorSupport {
      * Finalizes a record configuration after its children have been processed.
      * @param record the record configuration to process
      */
+    @Override
     protected void finalizeRecord(RecordConfig record) throws BeanIOConfigurationException {
         finalizeSegment(record);
         
@@ -274,6 +281,7 @@ public class Preprocessor extends ProcessorSupport {
      * Initializes a segment configuration before its children have been processed.
      * @param segment the segment configuration to process
      */
+    @Override
     protected void initializeSegment(SegmentConfig segment) throws BeanIOConfigurationException {
 
         if (segment.getName() == null) {
@@ -339,6 +347,7 @@ public class Preprocessor extends ProcessorSupport {
      * Finalizes a segment configuration after its children have been processed.
      * @param segment the segment configuration to process
      */
+    @Override
     protected void finalizeSegment(SegmentConfig segment) throws BeanIOConfigurationException {
         for (PropertyConfig child : segment.getPropertyList()) {
             if (child.isIdentifier()) {
@@ -352,6 +361,7 @@ public class Preprocessor extends ProcessorSupport {
      * Processes a field configuration.
      * @param field the field configuration to process
      */
+    @Override
     protected void handleField(FieldConfig field) throws BeanIOConfigurationException {
         // ignore fields that belong to ignored records
         if (recordIgnored) {
@@ -418,6 +428,7 @@ public class Preprocessor extends ProcessorSupport {
      * Processes a constant configuration.
      * @param constant the constant configuration to process
      */
+    @Override
     protected void handleConstant(ConstantConfig constant) throws BeanIOConfigurationException {
         constant.setBound(true);
         

--- a/src/org/beanio/internal/compiler/ProcessorSupport.java
+++ b/src/org/beanio/internal/compiler/ProcessorSupport.java
@@ -30,7 +30,7 @@ import org.beanio.internal.config.*;
  */
 public abstract class ProcessorSupport {
 
-    private LinkedList<ComponentConfig> configStack = new LinkedList<ComponentConfig>();
+    private LinkedList<ComponentConfig> configStack = new LinkedList<>();
     
     /**
      * Constructs a new <tt>ProcessorSupport</tt>.

--- a/src/org/beanio/internal/compiler/StreamCompiler.java
+++ b/src/org/beanio/internal/compiler/StreamCompiler.java
@@ -87,7 +87,7 @@ public class StreamCompiler {
         }
         
         // check for duplicate stream names...
-        HashSet<String> set = new HashSet<String>();
+        HashSet<String> set = new HashSet<>();
         for (BeanIOConfig config : configList) {
             for (StreamConfig streamConfig : config.getStreamList()) {
                 if (!set.add(streamConfig.getName())) {
@@ -103,7 +103,7 @@ public class StreamCompiler {
             return createStreamDefinitions(configList.iterator().next());
         }
         else {
-            List<Stream> list = new ArrayList<Stream>();
+            List<Stream> list = new ArrayList<>();
             for (BeanIOConfig config : configList) {
                 list.addAll(createStreamDefinitions(config));
             }
@@ -135,7 +135,7 @@ public class StreamCompiler {
             config.getTypeHandlerList());
         
         Collection<StreamConfig> streamConfigList = config.getStreamList();
-        Collection<Stream> streamDefinitionList = new ArrayList<Stream>(streamConfigList.size());
+        Collection<Stream> streamDefinitionList = new ArrayList<>(streamConfigList.size());
         
         for (StreamConfig streamConfig : streamConfigList) {
             

--- a/src/org/beanio/internal/compiler/accessor/ReflectionAccessorFactory.java
+++ b/src/org/beanio/internal/compiler/accessor/ReflectionAccessorFactory.java
@@ -19,6 +19,7 @@ public class ReflectionAccessorFactory implements PropertyAccessorFactory {
      * (non-Javadoc)
      * @see org.beanio.internal.compiler.PropertyAccessorFactory#getPropertyAccessor(java.lang.Class, java.beans.PropertyDescriptor, int)
      */
+    @Override
     public PropertyAccessor getPropertyAccessor(
         Class<?> parent, PropertyDescriptor descriptor, int carg) {
     
@@ -31,6 +32,7 @@ public class ReflectionAccessorFactory implements PropertyAccessorFactory {
      * (non-Javadoc)
      * @see org.beanio.internal.compiler.PropertyAccessorFactory#getPropertyAccessor(java.lang.Class, java.lang.reflect.Field, int)
      */
+    @Override
     public PropertyAccessor getPropertyAccessor(
         Class<?> parent, Field field, int carg) {
     

--- a/src/org/beanio/internal/compiler/flat/FlatParserFactory.java
+++ b/src/org/beanio/internal/compiler/flat/FlatParserFactory.java
@@ -53,6 +53,7 @@ public abstract class FlatParserFactory extends ParserFactorySupport {
          * (non-Javadoc)
          * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
          */
+        @Override
         public int compare(Component o1, Component o2) {
             return getPosition(o1).compareTo(getPosition(o2));
         }

--- a/src/org/beanio/internal/compiler/flat/FlatParserFactory.java
+++ b/src/org/beanio/internal/compiler/flat/FlatParserFactory.java
@@ -47,7 +47,7 @@ public abstract class FlatParserFactory extends ParserFactorySupport {
     @SuppressWarnings("unused")
     private static class NodeComparator implements Comparator<Component> {
 
-        private IdentityHashMap<Component, Integer> cache = new IdentityHashMap<Component, Integer>();
+        private IdentityHashMap<Component, Integer> cache = new IdentityHashMap<>();
         
         /*
          * (non-Javadoc)

--- a/src/org/beanio/internal/compiler/flat/FlatPreprocessor.java
+++ b/src/org/beanio/internal/compiler/flat/FlatPreprocessor.java
@@ -42,11 +42,11 @@ public class FlatPreprocessor extends Preprocessor {
     // the component that immediately follows the unbounded component
     private PropertyConfig unboundedComponentFollower = null;
     // the list of components at the end of the record following the unbounded component
-    private List<PropertyConfig> endComponents = new ArrayList<PropertyConfig>();
+    private List<PropertyConfig> endComponents = new ArrayList<>();
     /* stack of non-record segments */
-    private LinkedList<SegmentConfig> segmentStack = new LinkedList<SegmentConfig>();
+    private LinkedList<SegmentConfig> segmentStack = new LinkedList<>();
     /* list of field components belonging to a record, used for validating dynamic occurrences */
-    private List<FieldConfig> fieldComponents = new ArrayList<FieldConfig>();
+    private List<FieldConfig> fieldComponents = new ArrayList<>();
     
     /**
      * Constructs a new <tt>FlatPreprocessor</tt>.

--- a/src/org/beanio/internal/compiler/flat/FlatPreprocessor.java
+++ b/src/org/beanio/internal/compiler/flat/FlatPreprocessor.java
@@ -360,7 +360,7 @@ public class FlatPreprocessor extends Preprocessor {
             }
         }
         else {
-            if (new Integer(-1).equals(field.getLength())) {
+            if (Integer.valueOf(-1).equals(field.getLength())) {
                 field.setLength(null);
             }
         }

--- a/src/org/beanio/internal/compiler/json/JsonParserFactory.java
+++ b/src/org/beanio/internal/compiler/json/JsonParserFactory.java
@@ -147,7 +147,7 @@ public class JsonParserFactory extends ParserFactorySupport {
         format.setJsonName(config.getJsonName());
         format.setJsonArray(config.isJsonArray());
         format.setJsonArrayIndex(config.getJsonArrayIndex());
-        format.setLazy(config.getMinOccurs() != null && new Integer(0).equals(config.getMinOccurs()));
+        format.setLazy(config.getMinOccurs() != null && Integer.valueOf(0).equals(config.getMinOccurs()));
         format.setNillable(true); // for now, allow any JSON field to be nullable
         
         // default the JSON type based on the property type

--- a/src/org/beanio/internal/config/BeanIOConfig.java
+++ b/src/org/beanio/internal/config/BeanIOConfig.java
@@ -26,8 +26,8 @@ import java.util.*;
 public class BeanIOConfig implements Cloneable {
 
     private String source;
-    private List<StreamConfig> streamList = new ArrayList<StreamConfig>();
-    private List<TypeHandlerConfig> handlerList = new ArrayList<TypeHandlerConfig>();
+    private List<StreamConfig> streamList = new ArrayList<>();
+    private List<TypeHandlerConfig> handlerList = new ArrayList<>();
     
     /**
      * Constructs a new <tt>BeanIOConfig</tt>.

--- a/src/org/beanio/internal/config/GroupConfig.java
+++ b/src/org/beanio/internal/config/GroupConfig.java
@@ -48,6 +48,7 @@ public class GroupConfig extends PropertyConfig implements SelectorConfig {
      * number may appear in any order.
      * @return the order of this record
      */
+    @Override
     public Integer getOrder() {
         return order;
     }
@@ -58,6 +59,7 @@ public class GroupConfig extends PropertyConfig implements SelectorConfig {
      * number may appear in any order.
      * @param order the order of this record
      */
+    @Override
     public void setOrder(Integer order) {
         this.order = order;
     }
@@ -67,6 +69,7 @@ public class GroupConfig extends PropertyConfig implements SelectorConfig {
      * Map key when <tt>collection</tt> is set to <tt>map</tt>.
      * @return the key property name
      */
+    @Override
     public String getKey() {
         return key;
     }

--- a/src/org/beanio/internal/config/RecordConfig.java
+++ b/src/org/beanio/internal/config/RecordConfig.java
@@ -119,6 +119,7 @@ public class RecordConfig extends SegmentConfig implements SelectorConfig {
      * number may appear in any order.
      * @return the order of this record
      */
+    @Override
     public Integer getOrder() {
         return order;
     }
@@ -129,6 +130,7 @@ public class RecordConfig extends SegmentConfig implements SelectorConfig {
      * number may appear in any order.
      * @param order the order of this record
      */
+    @Override
     public void setOrder(Integer order) {
         this.order = order;
     }

--- a/src/org/beanio/internal/config/SegmentConfig.java
+++ b/src/org/beanio/internal/config/SegmentConfig.java
@@ -52,6 +52,7 @@ public class SegmentConfig extends PropertyConfig {
      * (non-Javadoc)
      * @see org.beanio.config.PropertyConfig#type()
      */
+    @Override
     public char getComponentType() {
         return SEGMENT;
     }
@@ -134,6 +135,7 @@ public class SegmentConfig extends PropertyConfig {
      * Map key when <tt>collection</tt> is set to <tt>map</tt>.
      * @return the key property name
      */
+    @Override
     public String getKey() {
         return key;
     }

--- a/src/org/beanio/internal/config/SegmentConfig.java
+++ b/src/org/beanio/internal/config/SegmentConfig.java
@@ -62,7 +62,7 @@ public class SegmentConfig extends PropertyConfig {
      * @return list of children
      */
     public List<PropertyConfig> getPropertyList() {
-        List<PropertyConfig> list = new ArrayList<PropertyConfig>(getChildren().size());
+        List<PropertyConfig> list = new ArrayList<>(getChildren().size());
         toPropertyList(this, list);
         return list;
     }

--- a/src/org/beanio/internal/config/StreamConfig.java
+++ b/src/org/beanio/internal/config/StreamConfig.java
@@ -45,7 +45,7 @@ public class StreamConfig extends GroupConfig {
     private boolean strict = false;
     private boolean ignoreUnidentifiedRecords = false;
     
-    private List<TypeHandlerConfig> handlerList = new ArrayList<TypeHandlerConfig>();
+    private List<TypeHandlerConfig> handlerList = new ArrayList<>();
     private BeanConfig<RecordParserFactory> parserFactory;
 
     /**

--- a/src/org/beanio/internal/config/annotation/AnnotationParser.java
+++ b/src/org/beanio/internal/config/annotation/AnnotationParser.java
@@ -35,6 +35,7 @@ import org.beanio.internal.util.TypeUtil;
 public class AnnotationParser {
 
     private static final Comparator<ComponentConfig> ORDINAL_COMPARATOR = new Comparator<ComponentConfig>() {
+        @Override
         public int compare(ComponentConfig c1, ComponentConfig c2) {
             Integer o1 = c1.getOrdinal();
             Integer o2 = c2.getOrdinal();

--- a/src/org/beanio/internal/config/annotation/AnnotationParser.java
+++ b/src/org/beanio/internal/config/annotation/AnnotationParser.java
@@ -754,7 +754,7 @@ public class AnnotationParser {
         if (val == null) {
             return null;
         }
-        if (val.compareTo(new Integer(0)) < 0) {
+        if (val.compareTo(Integer.valueOf(0)) < 0) {
             return Integer.MAX_VALUE;
         }
         return val;

--- a/src/org/beanio/internal/config/xml/XmlConfigurationLoader.java
+++ b/src/org/beanio/internal/config/xml/XmlConfigurationLoader.java
@@ -46,6 +46,7 @@ public class XmlConfigurationLoader implements ConfigurationLoader {
      * (non-Javadoc)
      * @see org.beanio.config.MultiConfigurationLoader#loadConfigurations(java.io.InputStream)
      */
+    @Override
     public Collection<BeanIOConfig> loadConfiguration(InputStream in, Properties properties) 
         throws IOException, BeanIOConfigurationException {
         return createParser().loadConfiguration(in, properties);

--- a/src/org/beanio/internal/config/xml/XmlMapping.java
+++ b/src/org/beanio/internal/config/xml/XmlMapping.java
@@ -35,8 +35,8 @@ public class XmlMapping {
     private XmlMapping parent;
     private Properties properties;
     private BeanIOConfig config = new BeanIOConfig();
-    private List<XmlMapping> importList = new LinkedList<XmlMapping>();
-    private Map<String,Element> templateMap = new HashMap<String,Element>();
+    private List<XmlMapping> importList = new LinkedList<>();
+    private Map<String,Element> templateMap = new HashMap<>();
     
     /**
      * Constructs a new <tt>XmlMapping</tt>.

--- a/src/org/beanio/internal/config/xml/XmlMappingParser.java
+++ b/src/org/beanio/internal/config/xml/XmlMappingParser.java
@@ -754,6 +754,7 @@ public class XmlMappingParser implements StringUtil.PropertySource {
      * (non-Javadoc)
      * @see org.beanio.internal.util.StringUtil.PropertiesSource#getProperty(java.lang.String)
      */
+    @Override
     public String getProperty(String key) {
         String value = null;
         if (properties != null) {

--- a/src/org/beanio/internal/config/xml/XmlMappingParser.java
+++ b/src/org/beanio/internal/config/xml/XmlMappingParser.java
@@ -54,7 +54,7 @@ public class XmlMappingParser implements StringUtil.PropertySource {
     /* whether the current record class was annotated */
     private transient boolean annotatedRecord = false;
     
-    private LinkedList<Include> includeStack = new LinkedList<Include>();
+    private LinkedList<Include> includeStack = new LinkedList<>();
 
     /**
      * Constructs a new <tt>XmlMappingParser</tt>.
@@ -86,7 +86,7 @@ public class XmlMappingParser implements StringUtil.PropertySource {
         this.properties = properties;
         
         mapping = new XmlMapping();
-        mappings = new HashMap<String,XmlMapping>();
+        mappings = new HashMap<>();
         mappings.put("[root]", mapping);
         
         try {
@@ -100,13 +100,13 @@ public class XmlMappingParser implements StringUtil.PropertySource {
             throw ex;
         }
         
-        List<BeanIOConfig> configList = new ArrayList<BeanIOConfig>(mappings.size());
+        List<BeanIOConfig> configList = new ArrayList<>(mappings.size());
         for (XmlMapping m : mappings.values()) {
             BeanIOConfig config = m.getConfiguration().clone();
             
             // global type handlers are the only elements that need to be imported
             // from other mapping files
-            List<TypeHandlerConfig> handlerList = new ArrayList<TypeHandlerConfig>();
+            List<TypeHandlerConfig> handlerList = new ArrayList<>();
             m.addTypeHandlers(handlerList);
             
             config.setTypeHandlerList(handlerList);

--- a/src/org/beanio/internal/config/xml/XmlMappingReader.java
+++ b/src/org/beanio/internal/config/xml/XmlMappingReader.java
@@ -65,7 +65,7 @@ public class XmlMappingReader {
             DocumentBuilder builder = factory.newDocumentBuilder();
             builder.setEntityResolver(createEntityResolver());
 
-            final List<String> errorMessages = new ArrayList<String>();
+            final List<String> errorMessages = new ArrayList<>();
 
             builder.setErrorHandler(new ErrorHandler() {
                 public void warning(SAXParseException exception) throws SAXException {

--- a/src/org/beanio/internal/config/xml/XmlMappingReader.java
+++ b/src/org/beanio/internal/config/xml/XmlMappingReader.java
@@ -68,16 +68,19 @@ public class XmlMappingReader {
             final List<String> errorMessages = new ArrayList<>();
 
             builder.setErrorHandler(new ErrorHandler() {
+                @Override
                 public void warning(SAXParseException exception) throws SAXException {
                     errorMessages.add("Error at line " + exception.getLineNumber() +
                         ": " + exception.getMessage());
                 }
 
+                @Override
                 public void error(SAXParseException exception) throws SAXException {
                     errorMessages.add("Error at line " + exception.getLineNumber() +
                         ": " + exception.getMessage());
                 }
 
+                @Override
                 public void fatalError(SAXParseException exception) throws SAXException {
                     throw exception;
                 }
@@ -138,6 +141,7 @@ public class XmlMappingReader {
     }
 
     private static class DefaultEntityResolver implements EntityResolver {
+        @Override
         public InputSource resolveEntity(String publicId, String systemId) throws SAXException,
             IOException {
             if (publicId == null && (BEANIO_XMLNS.equals(systemId) ||

--- a/src/org/beanio/internal/parser/Aggregation.java
+++ b/src/org/beanio/internal/parser/Aggregation.java
@@ -65,6 +65,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
      * (non-Javadoc)
      * @see org.beanio.parser2.Marshaller#marshal(org.beanio.parser2.MarshallingContext)
      */
+    @Override
     public final boolean marshal(MarshallingContext context) throws IOException {
         
         int min = minOccurs;
@@ -85,6 +86,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
      * (non-Javadoc)
      * @see org.beanio.parser2.Field#unmarshal(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public final boolean unmarshal(UnmarshallingContext context) {
         
         int min = minOccurs;
@@ -123,6 +125,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
      * (non-Javadoc)
      * @see org.beanio.parser2.DelegatingParser#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         if (occurs != null && !occurs.isBound()) {
             occurs.setValue(context, length(value));
@@ -145,6 +148,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
     /**
      * @throws UnsupportedOperationException
      */
+    @Override
     public void setIdentifier(boolean identifier) { 
         if (identifier) {
             throw new UnsupportedOperationException();
@@ -155,6 +159,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#getAccessor()
      */
+    @Override
     public PropertyAccessor getAccessor() {
         return accessor;
     }
@@ -163,6 +168,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#setAccessor(org.beanio.internal.parser.PropertyAccessor)
      */
+    @Override
     public void setAccessor(PropertyAccessor accessor) {
         this.accessor = accessor;
     }
@@ -171,6 +177,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
      * (non-Javadoc)
      * @see org.beanio.parser2.Iteration#getIterationIndex()
      */
+    @Override
     public final int getIterationIndex(ParsingContext context) {
         return index.get(context);
     }
@@ -211,6 +218,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
         this.lazy = lazy;
     }
     
+    @Override
     public boolean isDynamicIteration() {
         return occurs != null;
     }

--- a/src/org/beanio/internal/parser/Aggregation.java
+++ b/src/org/beanio/internal/parser/Aggregation.java
@@ -40,7 +40,7 @@ public abstract class Aggregation extends DelegatingParser implements Property, 
     protected Field occurs;
     
     // the current iteration index
-    private ParserLocal<Integer> index = new ParserLocal<Integer>();
+    private ParserLocal<Integer> index = new ParserLocal<>();
     
     /**
      * Constructs a new <tt>Aggregation</tt>.

--- a/src/org/beanio/internal/parser/ArrayParser.java
+++ b/src/org/beanio/internal/parser/ArrayParser.java
@@ -70,7 +70,7 @@ public class ArrayParser extends CollectionParser {
         if (value != null) {
             int length = Array.getLength(value);
             if (length > 0) {
-                collection = new ArrayList<Object>(length);
+                collection = new ArrayList<>(length);
                 for (int i=0; i<length; i++) {
                     collection.add(Array.get(value, i));
                 }
@@ -81,7 +81,7 @@ public class ArrayParser extends CollectionParser {
     
     @Override
     protected Collection<Object> createCollection() {
-        return new ArrayList<Object>();
+        return new ArrayList<>();
     }
 
     public Class<?> getArrayType() {

--- a/src/org/beanio/internal/parser/Bean.java
+++ b/src/org/beanio/internal/parser/Bean.java
@@ -34,6 +34,7 @@ public class Bean extends PropertyComponent implements Property {
 
     // the bean object
     private ParserLocal<Object> bean = new ParserLocal<Object>() {
+        @Override
         public Object createDefaultValue() {
             return isRequired() ? null : Value.MISSING;
         }
@@ -42,6 +43,7 @@ public class Bean extends PropertyComponent implements Property {
     private Constructor<?> constructor;
     // used to temporarily hold constructor argument values when a constructor is specified
     private ParserLocal<Object[]> constructorArgs = new ParserLocal<Object[]>() {
+        @Override
         public Object[] createDefaultValue() {
             return constructor != null ? new Object[constructor.getParameterTypes().length] : null;
         }
@@ -58,6 +60,7 @@ public class Bean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#clearValue()
      */
+    @Override
     public void clearValue(ParsingContext context) {
         for (Component child : getChildren()) {
             ((Property) child).clearValue(context);
@@ -69,6 +72,7 @@ public class Bean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#defines(java.lang.Object)
      */
+    @Override
     public boolean defines(Object bean) {   
         if (getType() == null) {
             return false;
@@ -110,6 +114,7 @@ public class Bean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#createValue()
      */
+    @Override
     public Object createValue(ParsingContext context) {
         Object b = null;
         
@@ -250,6 +255,7 @@ public class Bean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         return bean.get(context);
     }
@@ -258,6 +264,7 @@ public class Bean extends PropertyComponent implements Property {
      * Sets the bean object and populates all of its child properties.
      * 
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         if (value == null) {
             clearValue(context);
@@ -320,6 +327,7 @@ public class Bean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#type()
      */
+    @Override
     public int type() {
         return (isMap()) ? Property.MAP : Property.COMPLEX;
     }

--- a/src/org/beanio/internal/parser/BeanReaderImpl.java
+++ b/src/org/beanio/internal/parser/BeanReaderImpl.java
@@ -54,6 +54,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.BeanReader#read()
      */
+    @Override
     public Object read() {
         ensureOpen();
         
@@ -194,6 +195,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.BeanReader#skip(int)
      */
+    @Override
     public int skip(int count) throws BeanReaderIOException, MalformedRecordException,
         UnidentifiedRecordException, UnexpectedRecordException {
         
@@ -229,6 +231,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.impl.AbstractBeanReader#close()
      */
+    @Override
     public void close() throws BeanReaderIOException {
         ensureOpen();
         
@@ -247,6 +250,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.BeanReader#getName()
      */
+    @Override
     public String getRecordName() {
         return recordName;
     }
@@ -255,6 +259,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.BeanReader#getLineNumber()
      */
+    @Override
     public int getLineNumber() {
         return lineNumber;
     }
@@ -263,6 +268,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.BeanReader#getRecordCount()
      */
+    @Override
     public int getRecordCount() {
         return context == null ? 0: context.getRecordCount();
     }
@@ -271,6 +277,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.BeanReader#getRecordContext(int)
      */
+    @Override
     public RecordContext getRecordContext(int index) {
         if (context == null) {
             throw new IndexOutOfBoundsException();
@@ -282,6 +289,7 @@ public class BeanReaderImpl implements BeanReader {
      * (non-Javadoc)
      * @see org.beanio.BeanReader#setErrorHandler(org.beanio.BeanReaderErrorHandler)
      */
+    @Override
     public void setErrorHandler(BeanReaderErrorHandler errorHandler) {
         this.errorHandler = errorHandler;
     }
@@ -320,9 +328,11 @@ public class BeanReaderImpl implements BeanReader {
         this.ignoreUnidentifiedRecords = ignoreUnidentifiedRecords;
     }
     
+    @Override
     public void debug() {
         debug(System.out);
     }
+    @Override
     public void debug(PrintStream out) {
         ((Component)layout).print(out);
     }

--- a/src/org/beanio/internal/parser/BeanWriterImpl.java
+++ b/src/org/beanio/internal/parser/BeanWriterImpl.java
@@ -47,6 +47,7 @@ public class BeanWriterImpl implements BeanWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.BeanWriter#write(java.lang.Object)
      */
+    @Override
     public void write(Object bean) throws BeanWriterException {
         write(null, bean);
     }
@@ -55,6 +56,7 @@ public class BeanWriterImpl implements BeanWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.BeanWriter#write(java.lang.String, java.lang.Object)
      */
+    @Override
     public void write(String recordName, Object bean) throws BeanWriterException {
         ensureOpen();
         
@@ -103,6 +105,7 @@ public class BeanWriterImpl implements BeanWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.BeanWriter#flush()
      */
+    @Override
     public void flush() throws BeanWriterIOException {
         ensureOpen();
         
@@ -118,6 +121,7 @@ public class BeanWriterImpl implements BeanWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.BeanWriter#close()
      */
+    @Override
     public void close() throws BeanWriterIOException {
         ensureOpen();
         
@@ -146,6 +150,7 @@ public class BeanWriterImpl implements BeanWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.parser.StatefulBeanWriter#updateState(java.lang.String, java.util.Map)
      */
+    @Override
     public void updateState(String namespace, Map<String, Object> state) {
         layout.updateState(context, namespace + ".m", state);
         
@@ -159,6 +164,7 @@ public class BeanWriterImpl implements BeanWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.parser.StatefulBeanWriter#restoreState(java.lang.String, java.util.Map)
      */
+    @Override
     public void restoreState(String namespace, Map<String, Object> state) throws IllegalStateException {
         layout.restoreState(context, namespace + ".m", state);
         
@@ -168,9 +174,11 @@ public class BeanWriterImpl implements BeanWriter, StatefulWriter {
         }
     }
     
+    @Override
     public void debug() {
         debug(System.out);
     }
+    @Override
     public void debug(PrintStream out) {
         ((Component)layout).print(out);
     }

--- a/src/org/beanio/internal/parser/CollectionBean.java
+++ b/src/org/beanio/internal/parser/CollectionBean.java
@@ -43,6 +43,7 @@ public class CollectionBean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#type()
      */
+    @Override
     public int type() {
         return Property.COLLECTION;
     }
@@ -51,6 +52,7 @@ public class CollectionBean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyComponent#clearValue()
      */
+    @Override
     public void clearValue(ParsingContext context) {
         for (Component child : getChildren()) {
             ((Property) child).clearValue(context);
@@ -63,6 +65,7 @@ public class CollectionBean extends PropertyComponent implements Property {
      * @see org.beanio.internal.parser.PropertyComponent#createValue()
      */
     @SuppressWarnings("unchecked")
+    @Override
     public Object createValue(ParsingContext context) {
         Object b = null;
         
@@ -115,6 +118,7 @@ public class CollectionBean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyComponent#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         return bean.get(context);
     }
@@ -123,6 +127,7 @@ public class CollectionBean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyComponent#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         if (value == null) {
             clearValue(null);
@@ -146,6 +151,7 @@ public class CollectionBean extends PropertyComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyComponent#defines(java.lang.Object)
      */
+    @Override
     public boolean defines(Object value) {
         if (getType() == null) {
             return false;

--- a/src/org/beanio/internal/parser/CollectionParser.java
+++ b/src/org/beanio/internal/parser/CollectionParser.java
@@ -34,7 +34,7 @@ public class CollectionParser extends Aggregation {
     // the collection type
     private Class<? extends Collection<Object>> type;
     // the property value
-    private ParserLocal<Object> value = new ParserLocal<Object>();  
+    private ParserLocal<Object> value = new ParserLocal<>();  
     
     /**
      * Constructs a new <tt>CollectionParser</tt>.

--- a/src/org/beanio/internal/parser/CollectionParser.java
+++ b/src/org/beanio/internal/parser/CollectionParser.java
@@ -45,6 +45,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.DelegatingParser#clear()
      */
+    @Override
     public void clearValue(ParsingContext context) {
         this.value.set(context, null);
     }
@@ -53,6 +54,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#defines(java.lang.Object)
      */
+    @Override
     public boolean defines(Object value) {
         // TODO implement for arrays....
         
@@ -73,6 +75,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser.DelegatingParser#matches(org.beanio.parser.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         // matching repeating fields is not supported
         return true;
@@ -185,6 +188,7 @@ public class CollectionParser extends Aggregation {
      * Returns whether this iteration is a property of a bean object.
      * @return true if this iteration is a property, false otherwise
      */
+    @Override
     public boolean isProperty() {
         return type != null;
     }
@@ -222,6 +226,7 @@ public class CollectionParser extends Aggregation {
      * 
      */
     @SuppressWarnings("unchecked")
+    @Override
     public void setType(Class<?> collectionType) {
         this.type = (Class<? extends Collection<Object>>) collectionType;
     }
@@ -229,6 +234,7 @@ public class CollectionParser extends Aggregation {
     /*
      * Returns the property type.
      */
+    @Override
     public Class<? extends Collection<Object>> getType() {
         return type;
     }
@@ -237,6 +243,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#create()
      */
+    @Override
     public Object createValue(ParsingContext context) {
         Object value = this.value.get(context);
         if (value == null) {
@@ -250,6 +257,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.DelegatingParser#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         Object value = this.value.get(context);
         return value == null ? Value.MISSING : value;
@@ -259,6 +267,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.DelegatingParser#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         // convert empty collections to null so that parent parsers
         // will consider this property missing during marshalling
@@ -279,6 +288,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#type()
      */
+    @Override
     public int type() {
         return Property.AGGREGATION_COLLECTION;
     }
@@ -287,6 +297,7 @@ public class CollectionParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.Iteration#getIterationSize()
      */
+    @Override
     public int getIterationSize() {
         return getSize();
     }

--- a/src/org/beanio/internal/parser/Constant.java
+++ b/src/org/beanio/internal/parser/Constant.java
@@ -36,6 +36,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#type()
      */
+    @Override
     public int type() {
         return Property.SIMPLE;
     }
@@ -44,6 +45,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#defines(java.lang.Object)
      */
+    @Override
     public boolean defines(Object value) {
         return this.value.equals(value);
     }
@@ -52,12 +54,14 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#clearValue()
      */
+    @Override
     public void clearValue(ParsingContext context) { }
 
     /*
      * (non-Javadoc)
      * @see org.beanio.parser.Property#createValue()
      */
+    @Override
     public Object createValue(ParsingContext context) {
         return getValue(context);
     }
@@ -66,6 +70,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         return value;
     }
@@ -82,6 +87,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         
     }
@@ -90,6 +96,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#getType()
      */
+    @Override
     public Class<?> getType() {
         return type;
     }
@@ -98,6 +105,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#setType(java.lang.Class)
      */
+    @Override
     public void setType(Class<?> type) {
         this.type = type;
     }
@@ -106,6 +114,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#isIdentifier()
      */
+    @Override
     public boolean isIdentifier() {
         return identifier;
     }
@@ -114,6 +123,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#setIdentifier(boolean)
      */
+    @Override
     public void setIdentifier(boolean identifier) {
         this.identifier = identifier;
     }
@@ -122,6 +132,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#getAccessor()
      */
+    @Override
     public PropertyAccessor getAccessor() {
         return accessor;
     }
@@ -130,6 +141,7 @@ public class Constant extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Property#setAccessor(org.beanio.parser.PropertyAccessor)
      */
+    @Override
     public void setAccessor(PropertyAccessor accessor) {
         this.accessor = accessor;
     }

--- a/src/org/beanio/internal/parser/DelegatingParser.java
+++ b/src/org/beanio/internal/parser/DelegatingParser.java
@@ -31,42 +31,52 @@ public abstract class DelegatingParser extends ParserComponent {
         super(1);
     }
     
+    @Override
     public boolean matches(UnmarshallingContext context) {
         return getParser().matches(context);
     }
 
+    @Override
     public boolean unmarshal(UnmarshallingContext context) {
         return getParser().unmarshal(context);
     }
     
+    @Override
     public boolean marshal(MarshallingContext context) throws IOException {
         return getParser().marshal(context);
     }
 
+    @Override
     public void clearValue(ParsingContext context) {
         getParser().clearValue(context);
     }
 
+    @Override
     public void setValue(ParsingContext context, Object value) {
         getParser().setValue(context, value);
     }
 
+    @Override
     public Object getValue(ParsingContext context) {
         return getParser().getValue(context);
     }
 
+    @Override
     public int getSize() {
         return getParser().getSize();
     }
 
+    @Override
     public boolean isOptional() {
         return getParser().isOptional();
     }
     
+    @Override
     public boolean isIdentifier() {
         return getParser().isIdentifier();
     }
 
+    @Override
     public boolean hasContent(ParsingContext context) {
         return getParser().hasContent(context);
     }

--- a/src/org/beanio/internal/parser/ErrorContext.java
+++ b/src/org/beanio/internal/parser/ErrorContext.java
@@ -138,11 +138,11 @@ public class ErrorContext implements RecordContext, Cloneable {
      */
     public void addFieldError(String fieldName, String message) {
         if (fieldErrorMap == null) {
-            fieldErrorMap = new HashMap<String, Collection<String>>();
+            fieldErrorMap = new HashMap<>();
         }
         Collection<String> errors = fieldErrorMap.get(fieldName);
         if (errors == null) {
-            errors = new ArrayList<String>();
+            errors = new ArrayList<>();
             errors.add(message);
             fieldErrorMap.put(fieldName, errors);
         }
@@ -157,7 +157,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      */
     public void addRecordError(String message) {
         if (recordErrors == null) {
-            recordErrors = new ArrayList<String>(3);
+            recordErrors = new ArrayList<>(3);
         }
         recordErrors.add(message);
     }
@@ -170,13 +170,13 @@ public class ErrorContext implements RecordContext, Cloneable {
      */
     public void setFieldText(String fieldName, String text, boolean repeating) {
         if (fieldTextMap == null) {
-            fieldTextMap = new HashMap<String,String>();
+            fieldTextMap = new HashMap<>();
         }
         
         if (repeating) {
             // update the field count
             if (fieldCountMap == null) {
-                fieldCountMap = new HashMap<String,Counter>();
+                fieldCountMap = new HashMap<>();
             }
             
             Counter counter = fieldCountMap.get(fieldName);

--- a/src/org/beanio/internal/parser/ErrorContext.java
+++ b/src/org/beanio/internal/parser/ErrorContext.java
@@ -85,6 +85,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * Returns the raw text of the last record read from the record reader.
      * @return the raw text of the last record read
      */
+    @Override
     public String getRecordText() {
         return recordText;
     }
@@ -101,6 +102,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * Returns the starting line number of the last record read from the record reader.
      * @return the line number of the last record
      */
+    @Override
     public int getRecordLineNumber() {
         return lineNumber;
     }
@@ -119,6 +121,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * or <tt>null</tt> if not known.
      * @return the name of the record
      */
+    @Override
     public String getRecordName() {
         return recordName;
     }
@@ -198,6 +201,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.RecordContext#hasErrors()
      */
+    @Override
     public boolean hasErrors() {
         return hasRecordErrors() || hasFieldErrors();
     }
@@ -206,6 +210,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.BeanReaderContext#hasRecordErrors()
      */
+    @Override
     public boolean hasRecordErrors() {
         return recordErrors != null && !recordErrors.isEmpty();
     }
@@ -214,6 +219,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.BeanReaderContext#getRecordErrors()
      */
+    @Override
     public Collection<String> getRecordErrors() {
         if (recordErrors == null)
             return Collections.emptyList();
@@ -224,6 +230,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.RecordContext#getFieldCount(java.lang.String)
      */
+    @Override
     public int getFieldCount(String fieldName) {
         if (fieldTextMap == null) {
             return 0;
@@ -243,6 +250,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.BeanReaderContext#getFieldText(java.lang.String)
      */
+    @Override
     public String getFieldText(String fieldName) {
         return getFieldText(fieldName, 0);
     }
@@ -251,6 +259,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.BeanReaderContext#getFieldText(java.lang.String, int)
      */
+    @Override
     public String getFieldText(String fieldName, int index) {
         if (fieldTextMap == null) {
             return null;
@@ -267,6 +276,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.BeanReaderContext#hasFieldErrors()
      */
+    @Override
     public boolean hasFieldErrors() {
         return fieldErrorMap != null && !fieldErrorMap.isEmpty();
     }
@@ -275,6 +285,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.BeanReaderContext#getFieldErrors()
      */
+    @Override
     public Map<String, Collection<String>> getFieldErrors() {
         if (fieldErrorMap == null) {
             return Collections.emptyMap();
@@ -286,6 +297,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.BeanReaderContext#getFieldErrors(java.lang.String)
      */
+    @Override
     public Collection<String> getFieldErrors(String fieldName) {
         if (fieldErrorMap == null)
             return null;
@@ -297,6 +309,7 @@ public class ErrorContext implements RecordContext, Cloneable {
      * (non-Javadoc)
      * @see org.beanio.RecordContext#getLineNumber()
      */
+    @Override
     public int getLineNumber() {
         return getRecordLineNumber();
     }

--- a/src/org/beanio/internal/parser/Field.java
+++ b/src/org/beanio/internal/parser/Field.java
@@ -81,6 +81,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#hasContent()
      */
+    @Override
     public boolean hasContent(ParsingContext context) {
         if (isBound()) {
             return getValue(context) != Value.MISSING;
@@ -96,6 +97,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#type()
      */
+    @Override
     public int type() {
         return Property.SIMPLE;
     }
@@ -104,6 +106,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#isOptional()
      */
+    @Override
     public boolean isOptional() {
         return format.isLazy();
     }
@@ -112,6 +115,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#defines(java.lang.Object)
      */
+    @Override
     public boolean defines(Object value) {
         if (value == null) {
             return false;
@@ -134,6 +138,7 @@ public class Field extends ParserComponent implements Property {
      * @return <tt>true</tt> if the field text is a match or this field is not used
      *   to identify the record
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         if (isIdentifier()) {
             return isMatch(format.extract(context, false));
@@ -169,6 +174,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser2.Marshaller#marshal(org.beanio.parser2.MarshallingContext)
      */
+    @Override
     public boolean marshal(MarshallingContext context) {
         String text;
         if (literal != null) {
@@ -245,6 +251,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser2.Unmarshaller#unmarshal(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public boolean unmarshal(UnmarshallingContext context) {
         String text = format.extract(context, true);
         if (text == null) {
@@ -411,6 +418,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Parser#clearValue()
      */
+    @Override
     public void clearValue(ParsingContext context) {
         this.value.set(context, Value.MISSING);
     }
@@ -419,6 +427,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#createValue()
      */
+    @Override
     public Object createValue(ParsingContext context) {
         return getValue(context);
     }
@@ -427,6 +436,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Parser#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         return value.get(context);
     }
@@ -435,6 +445,7 @@ public class Field extends ParserComponent implements Property {
      * (non-Javadoc)
      * @see org.beanio.parser.Parser#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         this.value.set(context, value == null ? Value.MISSING : value);
     }
@@ -490,10 +501,12 @@ public class Field extends ParserComponent implements Property {
         return propertyType;
     }
 
+    @Override
     public boolean isIdentifier() {
         return identifier;
     }
     
+    @Override
     public void setIdentifier(boolean recordIdentifier) {
         this.identifier = recordIdentifier;
     }
@@ -514,6 +527,7 @@ public class Field extends ParserComponent implements Property {
         this.literal = literal;
     }
 
+    @Override
     public Class<?> getType() {
         return propertyType;
     }
@@ -562,14 +576,17 @@ public class Field extends ParserComponent implements Property {
         this.regex = regex;
     }
 
+    @Override
     public void setType(Class<?> type) {
         this.propertyType = type;
     }
     
+    @Override
     public PropertyAccessor getAccessor() {
         return accessor;
     }
 
+    @Override
     public void setAccessor(PropertyAccessor accessor) {
         this.accessor = accessor;
     }
@@ -600,6 +617,7 @@ public class Field extends ParserComponent implements Property {
         this.handler = handler;
     }
     
+    @Override
     protected void toParamString(StringBuilder s) {
         super.toParamString(s);
         s.append(", type=").append(propertyType != null ? propertyType.getSimpleName() : null);
@@ -622,6 +640,7 @@ public class Field extends ParserComponent implements Property {
         s.append(", format=").append(format);
     }
 
+    @Override
     public int getSize() {
         return format.getSize();
     }

--- a/src/org/beanio/internal/parser/Group.java
+++ b/src/org/beanio/internal/parser/Group.java
@@ -39,9 +39,9 @@ public class Group extends ParserComponent implements Selector {
     private int order = 1;
     private Property property = null;
     // the current group count
-    private ParserLocal<Integer> count = new ParserLocal<Integer>(0);
+    private ParserLocal<Integer> count = new ParserLocal<>(0);
     // the last matched child
-    private ParserLocal<Selector> lastMatched = new ParserLocal<Selector>();
+    private ParserLocal<Selector> lastMatched = new ParserLocal<>();
     
     /**
      * Constructs a new <tt>Group</tt>.

--- a/src/org/beanio/internal/parser/Group.java
+++ b/src/org/beanio/internal/parser/Group.java
@@ -54,6 +54,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Marshaller#marshal(org.beanio.parser2.MarshallingContext)
      */
+    @Override
     public boolean marshal(MarshallingContext context) throws IOException {
         // this method is only invoked when this group is configured to
         // marshal a bean object that spans multiple records
@@ -70,6 +71,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#skip(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public void skip(UnmarshallingContext context) {
         // this method is only invoked when this group is configured to
         // unmarshal a bean object that spans multiple records
@@ -109,6 +111,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Unmarshaller#unmarshal(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public boolean unmarshal(UnmarshallingContext context) {
         // this method is only invoked when this group is configured to
         // unmarshal a bean object that spans multiple records
@@ -157,6 +160,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.RecordMatcher#matchAny(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public Selector matchAny(UnmarshallingContext context) {
         for (Component n : getChildren()) {
             Selector node = (Selector) n;
@@ -173,6 +177,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.RecordMatcher#matchNext(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public Selector matchNext(UnmarshallingContext context) {
         try {
             return internalMatchNext(context);
@@ -186,6 +191,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.RecordMatcher#matchNextBean(java.lang.Object)
      */
+    @Override
     public Selector matchNext(MarshallingContext context) {
         try {
             if (property == null) {
@@ -419,6 +425,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#reset()
      */
+    @Override
     public void reset(ParsingContext context) {
         lastMatched.set(context, null);
         for (Component c : getChildren()) {
@@ -432,6 +439,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.RecordMatcher#close()
      */
+    @Override
     public Selector close(ParsingContext context) {
         Selector lastMatch = lastMatched.get(context);
         
@@ -483,6 +491,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Unmarshaller#matches(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         return false;
     }
@@ -491,6 +500,7 @@ public class Group extends ParserComponent implements Selector {
      * Tests if the max occurs has been reached for this node.
      * @return true if max occurs has been reached
      */
+    @Override
     public boolean isMaxOccursReached(ParsingContext context) {
         return lastMatched.get(context) == null && getCount(context) >= getMaxOccurs();
     }
@@ -499,6 +509,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Unmarshaller#getSize()
      */
+    @Override
     public int getSize() {
         return -1;
     }
@@ -510,6 +521,7 @@ public class Group extends ParserComponent implements Selector {
      * @param state the Map to update with the latest state
      * @since 1.2
      */
+    @Override
     public void updateState(ParsingContext context, String namespace, Map<String, Object> state) {
         state.put(getKey(namespace, COUNT_KEY), count.get(context));
         
@@ -533,6 +545,7 @@ public class Group extends ParserComponent implements Selector {
      * @param state the Map containing the state to restore
      * @since 1.2
      */
+    @Override
     public void restoreState(ParsingContext context, String namespace, Map<String, Object> state) {
         String key = getKey(namespace, COUNT_KEY);
         Integer n = (Integer) state.get(key);
@@ -577,25 +590,34 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#isRecordGroup()
      */
+    @Override
     public boolean isRecordGroup() {
         return true;
     }
 
+    @Override
     public int getMinOccurs() {
         return minOccurs;
     }
+
     public void setMinOccurs(int minOccurs) {
         this.minOccurs = minOccurs;
     }
+
+    @Override
     public int getMaxOccurs() {
         return maxOccurs;
     }
+
     public void setMaxOccurs(int maxOccurs) {
         this.maxOccurs = maxOccurs;
     }
+
+    @Override
     public int getOrder() {
         return order;
     }
+
     public void setOrder(int order) {
         this.order = order;
     }
@@ -604,6 +626,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getCount()
      */
+    @Override
     public int getCount(ParsingContext context) {
         return count.get(context);
     }
@@ -612,6 +635,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#setCount(int)
      */
+    @Override
     public void setCount(ParsingContext context, int count) {
         this.count.set(context, count);
     }
@@ -620,6 +644,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#clearValue()
      */
+    @Override
     public void clearValue(ParsingContext context) {
         if (property != null) {
             property.clearValue(context);
@@ -630,6 +655,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         property.setValue(context, value);
     }
@@ -638,11 +664,13 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         return property.getValue(context);
     }
     
     
+    @Override
     public Property getProperty() {
         return property;
     }
@@ -654,6 +682,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#isLazy()
      */
+    @Override
     public boolean isOptional() {
         return minOccurs == 0;
     }
@@ -662,6 +691,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#isIdentifier()
      */
+    @Override
     public boolean isIdentifier() {
         return false;
     }
@@ -670,6 +700,7 @@ public class Group extends ParserComponent implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#hasContent()
      */
+    @Override
     public boolean hasContent(ParsingContext context) {
         if (property != null) {
             return property.getValue(context) != Value.MISSING;

--- a/src/org/beanio/internal/parser/MapParser.java
+++ b/src/org/beanio/internal/parser/MapParser.java
@@ -34,7 +34,7 @@ public class MapParser extends Aggregation {
     // the child property used for the key
     private Property key;
     // the property value
-    private ParserLocal<Object> value = new ParserLocal<Object>();    
+    private ParserLocal<Object> value = new ParserLocal<>();    
     
     /**
      * Constructs a new <tt>MapParser</tt>.

--- a/src/org/beanio/internal/parser/MapParser.java
+++ b/src/org/beanio/internal/parser/MapParser.java
@@ -50,6 +50,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#defines(java.lang.Object)
      */
+    @Override
     public boolean defines(Object value) {
         if (value == null || type == null) {
             return false;
@@ -68,6 +69,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.DelegatingParser#matches(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         // matching repeating fields is not supported
         return true;
@@ -182,6 +184,7 @@ public class MapParser extends Aggregation {
      * Returns whether this iteration is a property of a bean object.
      * @return true if this iteration is a property, false otherwise
      */
+    @Override
     public boolean isProperty() {
         return type != null;
     }
@@ -190,6 +193,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#getType()
      */
+    @Override
     public Class<? extends Map<Object,Object>> getType() {
         return type;
     }
@@ -198,6 +202,7 @@ public class MapParser extends Aggregation {
      * Sets the concrete {@link Map} type.
      */
     @SuppressWarnings("unchecked")
+    @Override
     public void setType(Class<?> mapType) {
         this.type = (Class<? extends Map<Object,Object>>) mapType;
     }
@@ -206,6 +211,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.Property#create()
      */
+    @Override
     public Object createValue(ParsingContext context) {
         Object value = this.value.get(context);
         if (value == null) {
@@ -219,6 +225,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.DelegatingParser#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         Object value = this.value.get(context);
         return value == null ? Value.MISSING : value;
@@ -228,6 +235,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.parser2.DelegatingParser#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         // convert empty collections to null so that parent parsers
         // will consider this property missing during marshalling
@@ -269,6 +277,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Iteration#getIterationSize()
      */
+    @Override
     public int getIterationSize() {
         return getSize();
     }
@@ -277,6 +286,7 @@ public class MapParser extends Aggregation {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#type()
      */
+    @Override
     public int type() {
         return Property.AGGREGATION_MAP;
     }

--- a/src/org/beanio/internal/parser/MarshallerImpl.java
+++ b/src/org/beanio/internal/parser/MarshallerImpl.java
@@ -48,10 +48,13 @@ public class MarshallerImpl implements Marshaller {
         this.recordMarshaller = recordMarshaller;
         
         this.context.setRecordWriter(new RecordWriter() {
+            @Override
             public void write(Object record) {
                 recordValue = record;
             }
+            @Override
             public void flush() { }
+            @Override
             public void close() { }
         });
     }
@@ -60,6 +63,7 @@ public class MarshallerImpl implements Marshaller {
      * (non-Javadoc)
      * @see org.beanio.Marshaller#marshal(java.lang.Object)
      */
+    @Override
     public Marshaller marshal(Object bean) throws BeanWriterException {
         return marshal(null, bean);
     }
@@ -68,6 +72,7 @@ public class MarshallerImpl implements Marshaller {
      * (non-Javadoc)
      * @see org.beanio.Marshaller#marshal(java.lang.String, java.lang.Object)
      */
+    @Override
     public Marshaller marshal(String recordName, Object bean) throws BeanWriterException {
         recordValue = null;
         
@@ -126,6 +131,7 @@ public class MarshallerImpl implements Marshaller {
      * (non-Javadoc)
      * @see java.lang.Object#toString()
      */
+    @Override
     public String toString() {
         return (recordValue == null) ? null : recordMarshaller.marshal(recordValue);
     }
@@ -134,6 +140,7 @@ public class MarshallerImpl implements Marshaller {
      * (non-Javadoc)
      * @see org.beanio.Marshaller#toArray()
      */
+    @Override
     public String[] toArray() throws BeanWriterException {
         String[] array = context.toArray(recordValue);
         if (array == null) {
@@ -146,6 +153,7 @@ public class MarshallerImpl implements Marshaller {
      * (non-Javadoc)
      * @see org.beanio.Marshaller#toList()
      */
+    @Override
     public List<String> toList() throws BeanWriterException {
         List<String> list = context.toList(recordValue);
         if (list == null) {
@@ -158,6 +166,7 @@ public class MarshallerImpl implements Marshaller {
      * (non-Javadoc)
      * @see org.beanio.Marshaller#toDocument()
      */
+    @Override
     public Document toDocument() throws BeanWriterException {
         Document document = context.toDocument(recordValue);
         if (document == null) {
@@ -174,9 +183,11 @@ public class MarshallerImpl implements Marshaller {
         return recordValue;
     }
     
+    @Override
     public void debug() {
         debug(System.out);
     }
+    @Override
     public void debug(PrintStream out) {
         ((Component)layout).print(out);
     }

--- a/src/org/beanio/internal/parser/MarshallingContext.java
+++ b/src/org/beanio/internal/parser/MarshallingContext.java
@@ -50,6 +50,7 @@ public abstract class MarshallingContext extends ParsingContext {
     /**
      * Clear is invoked after each bean object (record or group) is marshalled.
      */
+    @Override
     public void clear() { 
         this.bean = null;
         this.componentName = null;

--- a/src/org/beanio/internal/parser/ParsingContext.java
+++ b/src/org/beanio/internal/parser/ParsingContext.java
@@ -32,7 +32,7 @@ public abstract class ParsingContext {
     
     private int fieldOffset = 0;
     private Object[] localHeap;
-    private ArrayList<Iteration> iterationStack = new ArrayList<Iteration>();
+    private ArrayList<Iteration> iterationStack = new ArrayList<>();
     
     /**
      * Constructs a new <tt>ParsingContext</tt>.

--- a/src/org/beanio/internal/parser/PropertyComponent.java
+++ b/src/org/beanio/internal/parser/PropertyComponent.java
@@ -50,6 +50,7 @@ public abstract class PropertyComponent extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#isIdentifier()
      */
+    @Override
     public boolean isIdentifier() {
         return identifier;
     }
@@ -58,6 +59,7 @@ public abstract class PropertyComponent extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#setIdentifier(boolean)
      */
+    @Override
     public void setIdentifier(boolean identifier) {
         this.identifier = identifier;
     }
@@ -66,6 +68,7 @@ public abstract class PropertyComponent extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#getAccessor()
      */
+    @Override
     public PropertyAccessor getAccessor() {
         return accessor;
     }
@@ -74,6 +77,7 @@ public abstract class PropertyComponent extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#setAccessor(org.beanio.internal.parser.PropertyAccessor)
      */
+    @Override
     public void setAccessor(PropertyAccessor accessor) {
         this.accessor = accessor;
     }
@@ -82,6 +86,7 @@ public abstract class PropertyComponent extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#getType()
      */
+    @Override
     public Class<?> getType() {
         return type;
     }
@@ -90,6 +95,7 @@ public abstract class PropertyComponent extends Component implements Property {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#setType(java.lang.Class)
      */
+    @Override
     public void setType(Class<?> type) {
         this.type = type;
     }

--- a/src/org/beanio/internal/parser/Record.java
+++ b/src/org/beanio/internal/parser/Record.java
@@ -36,7 +36,7 @@ public class Record extends Segment implements Selector {
     // the record format
     private RecordFormat format;
     // current record count
-    private ParserLocal<Integer> count = new ParserLocal<Integer>(0);
+    private ParserLocal<Integer> count = new ParserLocal<>(0);
 
     /**
      * Constructs a new <tt>Record</tt>.

--- a/src/org/beanio/internal/parser/Record.java
+++ b/src/org/beanio/internal/parser/Record.java
@@ -47,6 +47,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Marshaller#marshal(org.beanio.parser2.MarshallingContext)
      */
+    @Override
     public boolean marshal(MarshallingContext context) throws IOException {
         try {
             boolean marshalled = super.marshal(context);
@@ -65,6 +66,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Unmarshaller#unmarshal(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public boolean unmarshal(UnmarshallingContext context) {
         try {
             // update the record context before unmarshalling
@@ -92,6 +94,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#skip(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public void skip(UnmarshallingContext context) {
         context.recordSkipped();
     }
@@ -100,6 +103,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchNext(org.beanio.internal.parser.MarshallingContext)
      */
+    @Override
     public Selector matchNext(MarshallingContext context) {
         Property property = getProperty();
         if (property != null) {
@@ -129,6 +133,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchNext(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public Selector matchNext(UnmarshallingContext context) {
         if (matches(context)) {
             setCount(context, getCount(context) + 1);
@@ -141,6 +146,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.parser2.Unmarshaller#matches(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         if (format != null) {
             if (!format.matches(context)) {
@@ -154,6 +160,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchAny(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public Selector matchAny(UnmarshallingContext context) {
         return matches(context) ? this : null;
     }
@@ -162,6 +169,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#close(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public Selector close(ParsingContext context) {
         return getCount(context) < getMinOccurs() ? this : null;
     }
@@ -170,6 +178,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#reset(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public void reset(ParsingContext context) { }
     
     /**
@@ -179,6 +188,7 @@ public class Record extends Segment implements Selector {
      * @param state the Map to update with the latest state
      * @since 1.2
      */
+    @Override
     public void updateState(ParsingContext context, String namespace, Map<String, Object> state) {
         state.put(getKey(namespace, COUNT_KEY), count.get(context));
     }
@@ -190,6 +200,7 @@ public class Record extends Segment implements Selector {
      * @param state the Map containing the state to restore
      * @since 1.2
      */
+    @Override
     public void restoreState(ParsingContext context, String namespace, Map<String, Object> state) {
         String key = getKey(namespace, COUNT_KEY);
         Integer n = (Integer) state.get(key);
@@ -213,31 +224,37 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#isRecordGroup()
      */
+    @Override
     public boolean isRecordGroup() {
         return false;
     }
     
+    @Override
     public int getMinOccurs() {
         return minOccurs;
     }
     public void setMinOccurs(int minOccurs) {
         this.minOccurs = minOccurs;
     }
+    @Override
     public int getMaxOccurs() {
         return maxOccurs;
     }
     public void setMaxOccurs(int maxOccurs) {
         this.maxOccurs = maxOccurs;
     }
+    @Override
     public int getOrder() {
         return order;
     }
     public void setOrder(int order) {
         this.order = order;
     }
+    @Override
     public int getCount(ParsingContext context) {
         return count.get(context);
     }
+    @Override
     public void setCount(ParsingContext context, int count) {
         this.count.set(context, count);
     }
@@ -259,6 +276,7 @@ public class Record extends Segment implements Selector {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#isMaxOccursReached()
      */
+    @Override
     public boolean isMaxOccursReached(ParsingContext context) {
         return getCount(context) >= getMaxOccurs();
     }

--- a/src/org/beanio/internal/parser/RecordAggregation.java
+++ b/src/org/beanio/internal/parser/RecordAggregation.java
@@ -44,6 +44,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * Sets the collection type.
      * @param type {@link Collection} class type
      */
+    @Override
     public void setType(Class<?> type) {
         this.type = type;
     }
@@ -52,6 +53,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#getType()
      */
+    @Override
     public Class<?> getType() {
         return type;
     }
@@ -60,6 +62,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#createValue()
      */
+    @Override
     public Object createValue(ParsingContext context) {
         if (value.get(context) == Value.MISSING) {
             value.set(context, createAggregationType());
@@ -98,6 +101,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getProperty()
      */
+    @Override
     public Property getProperty() {
         // for now, a collection cannot be a property root so its safe to return null here
         return null;
@@ -107,6 +111,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchNextRecord(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public Selector matchNext(UnmarshallingContext context) {
         if (getSelector().matchNext(context) != null) {
             return this;
@@ -118,6 +123,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchAny(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public Selector matchAny(UnmarshallingContext context) {
         return getSelector().matchAny(context);
     }
@@ -126,6 +132,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchNextBean(org.beanio.internal.parser.MarshallingContext, java.lang.Object)
      */
+    @Override
     public Selector matchNext(MarshallingContext context) {
         return getSelector().matchNext(context);
     }
@@ -134,6 +141,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#close(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public Selector close(ParsingContext context) {
         return getSelector().close(context);
     }
@@ -142,6 +150,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#reset(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public void reset(ParsingContext context) {
         getSelector().reset(context);
     }
@@ -150,6 +159,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getCount(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public int getCount(ParsingContext context) {
         return getSelector().getCount(context);
     }
@@ -158,6 +168,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#setCount(org.beanio.internal.parser.ParsingContext, int)
      */
+    @Override
     public void setCount(ParsingContext context, int count) {
         getSelector().setCount(context, count);
     }
@@ -166,6 +177,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getOrder()
      */
+    @Override
     public int getOrder() {
         return getSelector().getOrder();
     }
@@ -174,6 +186,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#isMaxOccursReached(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public boolean isMaxOccursReached(ParsingContext context) {
         return getSelector().isMaxOccursReached(context);
     }
@@ -182,6 +195,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.util.StatefulWriter#updateState(java.lang.String, java.util.Map)
      */
+    @Override
     public void updateState(ParsingContext context, String namespace, Map<String, Object> state) {
         getSelector().updateState(context, namespace, state);
     }
@@ -190,6 +204,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.util.StatefulWriter#restoreState(java.lang.String, java.util.Map)
      */
+    @Override
     public void restoreState(ParsingContext context, String namespace, Map<String, Object> state) throws IllegalStateException {
         getSelector().restoreState(context, namespace, state);
     }
@@ -198,6 +213,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getMinOccurs()
      */
+    @Override
     public int getMinOccurs() {
         return getSelector().getMinOccurs();
     }
@@ -206,6 +222,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getMaxOccurs()
      */
+    @Override
     public int getMaxOccurs() {
         return getSelector().getMaxOccurs();
     }
@@ -235,6 +252,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#getAccessor()
      */
+    @Override
     public PropertyAccessor getAccessor() {
         return accessor;
     }
@@ -243,6 +261,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#setAccessor(org.beanio.internal.parser.PropertyAccessor)
      */
+    @Override
     public void setAccessor(PropertyAccessor accessor) {
         this.accessor = accessor;
     }
@@ -251,6 +270,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#defines(java.lang.Object)
      */
+    @Override
     public boolean defines(Object value) {
         throw new IllegalStateException("RecordAggregation cannot identify a bean");
     }
@@ -259,6 +279,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#setIdentifier(boolean)
      */
+    @Override
     public void setIdentifier(boolean identifier) {
         // a collection cannot be used to identify a bean
     }
@@ -280,6 +301,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#skip(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public void skip(UnmarshallingContext context) {
         getSelector().skip(context);
     }
@@ -288,6 +310,7 @@ public abstract class RecordAggregation extends DelegatingParser implements Sele
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#isRecordGroup()
      */
+    @Override
     public boolean isRecordGroup() {
         return false;
     }

--- a/src/org/beanio/internal/parser/RecordArray.java
+++ b/src/org/beanio/internal/parser/RecordArray.java
@@ -69,7 +69,7 @@ public class RecordArray extends RecordCollection {
         if (value != null) {
             int length = Array.getLength(value);
             if (length > 0) {
-                collection = new ArrayList<Object>(length);
+                collection = new ArrayList<>(length);
                 for (int i=0; i<length; i++) {
                     collection.add(Array.get(value, i));
                 }
@@ -80,7 +80,7 @@ public class RecordArray extends RecordCollection {
     
     @Override
     protected Collection<Object> createAggregationType() {
-        return new ArrayList<Object>();
+        return new ArrayList<>();
     }
 
     /**

--- a/src/org/beanio/internal/parser/RecordCollection.java
+++ b/src/org/beanio/internal/parser/RecordCollection.java
@@ -122,6 +122,7 @@ public class RecordCollection extends RecordAggregation {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#type()
      */
+    @Override
     public int type() {
         return Property.AGGREGATION_COLLECTION;
     }

--- a/src/org/beanio/internal/parser/RecordMap.java
+++ b/src/org/beanio/internal/parser/RecordMap.java
@@ -131,6 +131,7 @@ public class RecordMap extends RecordAggregation {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Property#type()
      */
+    @Override
     public int type() {
         return Property.AGGREGATION_MAP;
     }

--- a/src/org/beanio/internal/parser/Segment.java
+++ b/src/org/beanio/internal/parser/Segment.java
@@ -50,6 +50,7 @@ public class Segment extends ParserComponent {
     private Property property;
     // temporarily stores missing children during unmarshalling
     private ParserLocal<List<Parser>> missing = new ParserLocal<List<Parser>>() {
+        @Override
         protected List<Parser> createDefaultValue() {
             return new ArrayList<>();
         }
@@ -64,6 +65,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#clearValue()
      */
+    @Override
     public void clearValue(ParsingContext context) {
         if (property != null) {
             property.clearValue(context);
@@ -74,6 +76,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#matches(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         if (isIdentifier()) {
             for (Component node : getChildren()) {
@@ -89,6 +92,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#unmarshal(org.beanio.parser2.UnmarshallingContext)
      */
+    @Override
     public boolean unmarshal(UnmarshallingContext context) {
         List<Parser> missing = this.missing.get(context);
         
@@ -134,6 +138,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#marshal(org.beanio.parser2.MarshallingContext)
      */
+    @Override
     public boolean marshal(MarshallingContext context) throws IOException {
         // since we allow Collections containing a null reference to force
         // output of a bean, we also check that we are not repeating
@@ -154,6 +159,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#hasContent()
      */
+    @Override
     public boolean hasContent(ParsingContext context) {
         if (property != null) {
             return property.getValue(context) != Value.MISSING;
@@ -172,6 +178,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         // getValue() may be called for a record where no property is set
         if (property == null) {
@@ -186,6 +193,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.parser2.Parser#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         if (property != null) {
             property.setValue(context, value);
@@ -204,6 +212,7 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.parser.Parser#isLazy()
      */
+    @Override
     public boolean isOptional() {
         return optional;
     }
@@ -220,10 +229,12 @@ public class Segment extends ParserComponent {
      * (non-Javadoc)
      * @see org.beanio.parser.Parser#getSize()
      */
+    @Override
     public int getSize() {
         return size;
     }
     
+    @Override
     public boolean isIdentifier() {
         return identifier;
     }

--- a/src/org/beanio/internal/parser/Segment.java
+++ b/src/org/beanio/internal/parser/Segment.java
@@ -51,7 +51,7 @@ public class Segment extends ParserComponent {
     // temporarily stores missing children during unmarshalling
     private ParserLocal<List<Parser>> missing = new ParserLocal<List<Parser>>() {
         protected List<Parser> createDefaultValue() {
-            return new ArrayList<Parser>();
+            return new ArrayList<>();
         }
     };
     

--- a/src/org/beanio/internal/parser/StreamFormatSupport.java
+++ b/src/org/beanio/internal/parser/StreamFormatSupport.java
@@ -47,6 +47,7 @@ public abstract class StreamFormatSupport implements StreamFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#getName()
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -57,6 +58,7 @@ public abstract class StreamFormatSupport implements StreamFormat {
      * @param in the input stream to read from
      * @return a new <tt>RecordReader</tt>
      */
+    @Override
     public RecordReader createRecordReader(Reader in) {
         return recordParserFactory.createReader(in);
     }
@@ -67,6 +69,7 @@ public abstract class StreamFormatSupport implements StreamFormat {
      * @param out the output stream to write to
      * @return a new <tt>RecordWriter</tt>
      */
+    @Override
     public RecordWriter createRecordWriter(Writer out) {
         return recordParserFactory.createWriter(out);
     }
@@ -75,6 +78,7 @@ public abstract class StreamFormatSupport implements StreamFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createRecordMarshaller()
      */
+    @Override
     public RecordMarshaller createRecordMarshaller() {
         return recordParserFactory.createMarshaller();
     }
@@ -83,6 +87,7 @@ public abstract class StreamFormatSupport implements StreamFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createRecordUnmarshaller()
      */
+    @Override
     public RecordUnmarshaller createRecordUnmarshaller() {
         return recordParserFactory.createUnmarshaller();
     }

--- a/src/org/beanio/internal/parser/UnmarshallerImpl.java
+++ b/src/org/beanio/internal/parser/UnmarshallerImpl.java
@@ -48,6 +48,7 @@ public class UnmarshallerImpl implements Unmarshaller {
         this.layout = layout;
         
         this.context.setRecordReader(new RecordReader() {
+            @Override
             public Object read() throws RecordIOException {
                 try {
                     Object value = recordValue;
@@ -61,12 +62,15 @@ public class UnmarshallerImpl implements Unmarshaller {
                     recordValue = null;
                 }
             }
+            @Override
             public int getRecordLineNumber() {
                 return 0;
             }
+            @Override
             public String getRecordText() {
                 return recordText;
             }
+            @Override
             public void close() throws IOException { }
         });
     }
@@ -75,6 +79,7 @@ public class UnmarshallerImpl implements Unmarshaller {
      * (non-Javadoc)
      * @see org.beanio.Unmarshaller#unmarshal(java.lang.String)
      */
+    @Override
     public Object unmarshal(String text) throws MalformedRecordException, UnidentifiedRecordException,
         UnexpectedRecordException, InvalidRecordException {
         
@@ -92,6 +97,7 @@ public class UnmarshallerImpl implements Unmarshaller {
      * (non-Javadoc)
      * @see org.beanio.Unmarshaller#unmarshal(java.util.List)
      */
+    @Override
     public Object unmarshal(List<String> list) throws BeanReaderException, UnidentifiedRecordException,
         UnexpectedRecordException, InvalidRecordException {
         
@@ -113,6 +119,7 @@ public class UnmarshallerImpl implements Unmarshaller {
      * (non-Javadoc)
      * @see org.beanio.Unmarshaller#unmarshal(java.lang.String[])
      */
+    @Override
     public Object unmarshal(String[] array) throws BeanReaderException, UnidentifiedRecordException,
         UnexpectedRecordException, InvalidRecordException {
         
@@ -134,6 +141,7 @@ public class UnmarshallerImpl implements Unmarshaller {
      * (non-Javadoc)
      * @see org.beanio.Unmarshaller#unmarshal(org.w3c.dom.Node)
      */
+    @Override
     public Object unmarshal(Node node) throws BeanReaderException, UnidentifiedRecordException,
         UnexpectedRecordException, InvalidRecordException {
         
@@ -216,6 +224,7 @@ public class UnmarshallerImpl implements Unmarshaller {
      * (non-Javadoc)
      * @see org.beanio.Unmarshaller#getRecordName()
      */
+    @Override
     public String getRecordName() {
         return recordName;
     }
@@ -224,13 +233,16 @@ public class UnmarshallerImpl implements Unmarshaller {
      * (non-Javadoc)
      * @see org.beanio.Unmarshaller#getRecordContext()
      */
+    @Override
     public RecordContext getRecordContext() {
         return context.getRecordContext(0);
     }
     
+    @Override
     public void debug() {
         debug(System.out);
     }
+    @Override
     public void debug(PrintStream out) {
         ((Component)layout).print(out);
     }

--- a/src/org/beanio/internal/parser/UnmarshallingContext.java
+++ b/src/org/beanio/internal/parser/UnmarshallingContext.java
@@ -57,7 +57,7 @@ public abstract class UnmarshallingContext extends ParsingContext {
     // indicates the record context was queried and must therefore be recreated when the next record is read 
     private boolean dirty;
     // a list of record contexts (for parsing record groups)
-    private List<ErrorContext> recordList = new ArrayList<ErrorContext>();
+    private List<ErrorContext> recordList = new ArrayList<>();
     
     /**
      * Constructs a new <tt>UnmarshallingContext</tt>.

--- a/src/org/beanio/internal/parser/accessor/FieldReflectionAccessor.java
+++ b/src/org/beanio/internal/parser/accessor/FieldReflectionAccessor.java
@@ -44,6 +44,7 @@ public class FieldReflectionAccessor extends PropertyAccessorSupport implements 
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyAccessor#getValue(java.lang.Object)
      */
+    @Override
     public Object getValue(Object bean) {
         try {
             return field.get(bean);
@@ -58,6 +59,7 @@ public class FieldReflectionAccessor extends PropertyAccessorSupport implements 
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyAccessor#setValue(java.lang.Object, java.lang.Object)
      */
+    @Override
     public void setValue(Object bean, Object value) {
         try {
             field.set(bean, value);

--- a/src/org/beanio/internal/parser/accessor/MapAccessor.java
+++ b/src/org/beanio/internal/parser/accessor/MapAccessor.java
@@ -42,6 +42,7 @@ public class MapAccessor implements PropertyAccessor {
      * @see org.beanio.parser.PropertyAccessor#getValue(java.lang.Object)
      */
     @SuppressWarnings("rawtypes")
+    @Override
     public Object getValue(Object bean) {
         return ((Map)bean).get(key);
     }
@@ -51,6 +52,7 @@ public class MapAccessor implements PropertyAccessor {
      * @see org.beanio.parser.PropertyAccessor#setValue(java.lang.Object, java.lang.Object)
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
     public void setValue(Object bean, Object value) {
         ((Map)bean).put(key, value);
     }
@@ -59,6 +61,7 @@ public class MapAccessor implements PropertyAccessor {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyAccessor#isConstructorArgument()
      */
+    @Override
     public boolean isConstructorArgument() {
         return false;
     }
@@ -67,6 +70,7 @@ public class MapAccessor implements PropertyAccessor {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyAccessor#getConstructorArgumentIndex()
      */
+    @Override
     public int getConstructorArgumentIndex() {
         return -1;
     }

--- a/src/org/beanio/internal/parser/accessor/MethodReflectionAccessor.java
+++ b/src/org/beanio/internal/parser/accessor/MethodReflectionAccessor.java
@@ -52,6 +52,7 @@ public class MethodReflectionAccessor extends PropertyAccessorSupport implements
      * (non-Javadoc)
      * @see org.beanio.parser.PropertyAccessor#getValue(java.lang.Object)
      */
+    @Override
     public Object getValue(Object bean) {
         if (getter == null) {
             throw new BeanIOException("There is no readable property named '" + 
@@ -72,6 +73,7 @@ public class MethodReflectionAccessor extends PropertyAccessorSupport implements
      * (non-Javadoc)
      * @see org.beanio.parser.PropertyAccessor#setValue(java.lang.Object, java.lang.Object)
      */
+    @Override
     public void setValue(Object bean, Object value) {
         if (setter == null) {
             throw new BeanIOException(

--- a/src/org/beanio/internal/parser/accessor/PropertyAccessorSupport.java
+++ b/src/org/beanio/internal/parser/accessor/PropertyAccessorSupport.java
@@ -36,6 +36,7 @@ public abstract class PropertyAccessorSupport implements PropertyAccessor {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyAccessor#isConstructorArgument()
      */
+    @Override
     public boolean isConstructorArgument() {
         return getConstructorArgumentIndex() >= 0;
     }
@@ -53,6 +54,7 @@ public abstract class PropertyAccessorSupport implements PropertyAccessor {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.PropertyAccessor#getConstructorArgumentIndex()
      */
+    @Override
     public int getConstructorArgumentIndex() {
         return constructorArgumentIndex;
     }

--- a/src/org/beanio/internal/parser/format/delimited/DelimitedMarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/delimited/DelimitedMarshallingContext.java
@@ -30,9 +30,9 @@ public class DelimitedMarshallingContext extends MarshallingContext {
     // the index of the last committed field in the record
     private int committed = 0;
     // the list used to build the final record
-    private ArrayList<String> record = new ArrayList<String>();
+    private ArrayList<String> record = new ArrayList<>();
     // the list of entries for creating the record (may be unordered)
-    private ArrayList<Entry> entries = new ArrayList<Entry>();
+    private ArrayList<Entry> entries = new ArrayList<>();
     
     /**
      * Constructs a new <tt>DelimitedMarshallingContext</tt>.

--- a/src/org/beanio/internal/parser/format/delimited/DelimitedMarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/delimited/DelimitedMarshallingContext.java
@@ -142,7 +142,7 @@ public class DelimitedMarshallingContext extends MarshallingContext {
         }
         
         public int compareTo(Entry o) {
-            return new Integer(this.order).compareTo(o.order);
+            return Integer.valueOf(this.order).compareTo(o.order);
         }
         
         @Override

--- a/src/org/beanio/internal/parser/format/delimited/DelimitedMarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/delimited/DelimitedMarshallingContext.java
@@ -141,6 +141,7 @@ public class DelimitedMarshallingContext extends MarshallingContext {
             this.text = text;
         }
         
+        @Override
         public int compareTo(Entry o) {
             return Integer.valueOf(this.order).compareTo(o.order);
         }

--- a/src/org/beanio/internal/parser/format/delimited/DelimitedRecordFormat.java
+++ b/src/org/beanio/internal/parser/format/delimited/DelimitedRecordFormat.java
@@ -44,6 +44,7 @@ public class DelimitedRecordFormat implements RecordFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.RecordFormat#matches(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         int length = ((DelimitedUnmarshallingContext)context).getFieldCount();
         return !(length < minMatchLength || length > maxMatchLength);
@@ -53,6 +54,7 @@ public class DelimitedRecordFormat implements RecordFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.RecordFormat#validate(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public void validate(UnmarshallingContext context) {
         int length = ((DelimitedUnmarshallingContext)context).getFieldCount();
         

--- a/src/org/beanio/internal/parser/format/delimited/DelimitedStreamFormat.java
+++ b/src/org/beanio/internal/parser/format/delimited/DelimitedStreamFormat.java
@@ -29,6 +29,7 @@ public class DelimitedStreamFormat extends StreamFormatSupport {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createUnmarshallingContext()
      */
+    @Override
     public UnmarshallingContext createUnmarshallingContext() {
         return new DelimitedUnmarshallingContext();
     }
@@ -37,6 +38,7 @@ public class DelimitedStreamFormat extends StreamFormatSupport {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createMarshallingContext()
      */
+    @Override
     public MarshallingContext createMarshallingContext(boolean streaming) {
         return new DelimitedMarshallingContext();
     }

--- a/src/org/beanio/internal/parser/format/fixedlength/FixedLengthMarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/fixedlength/FixedLengthMarshallingContext.java
@@ -133,7 +133,7 @@ public class FixedLengthMarshallingContext extends MarshallingContext {
         }
         
         public int compareTo(Entry o) {
-            return new Integer(this.order).compareTo(o.order);
+            return Integer.valueOf(this.order).compareTo(o.order);
         }
         
         @Override

--- a/src/org/beanio/internal/parser/format/fixedlength/FixedLengthMarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/fixedlength/FixedLengthMarshallingContext.java
@@ -33,7 +33,7 @@ public class FixedLengthMarshallingContext extends MarshallingContext {
     // appending the last required field
     private int committed = 0;
     // the list of entries for creating the record (may be unordered)
-    private ArrayList<Entry> entries = new ArrayList<Entry>();
+    private ArrayList<Entry> entries = new ArrayList<>();
     
     /**
      * Constructs a new <tt>FixedLengthMarshallingContext</tt>.

--- a/src/org/beanio/internal/parser/format/fixedlength/FixedLengthMarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/fixedlength/FixedLengthMarshallingContext.java
@@ -132,6 +132,7 @@ public class FixedLengthMarshallingContext extends MarshallingContext {
             this.text = text;
         }
         
+        @Override
         public int compareTo(Entry o) {
             return Integer.valueOf(this.order).compareTo(o.order);
         }

--- a/src/org/beanio/internal/parser/format/fixedlength/FixedLengthRecordFormat.java
+++ b/src/org/beanio/internal/parser/format/fixedlength/FixedLengthRecordFormat.java
@@ -43,6 +43,7 @@ public class FixedLengthRecordFormat implements RecordFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.RecordFormat#matches(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         int length = ((FixedLengthUnmarshallingContext)context).getRecordLength();
         return !(length < minMatchLength || length > maxMatchLength);
@@ -52,6 +53,7 @@ public class FixedLengthRecordFormat implements RecordFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.RecordFormat#validate(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public void validate(UnmarshallingContext context) {
         int length = ((FixedLengthUnmarshallingContext)context).getRecordLength();
         

--- a/src/org/beanio/internal/parser/format/fixedlength/FixedLengthStreamFormat.java
+++ b/src/org/beanio/internal/parser/format/fixedlength/FixedLengthStreamFormat.java
@@ -38,6 +38,7 @@ public class FixedLengthStreamFormat extends StreamFormatSupport {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createUnmarshallingContext()
      */
+    @Override
     public UnmarshallingContext createUnmarshallingContext() {
         return new FixedLengthUnmarshallingContext();
     }
@@ -46,6 +47,7 @@ public class FixedLengthStreamFormat extends StreamFormatSupport {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createMarshallingContext()
      */
+    @Override
     public MarshallingContext createMarshallingContext(boolean streaming) {
         return new FixedLengthMarshallingContext();
     }

--- a/src/org/beanio/internal/parser/format/flat/FlatFieldFormatSupport.java
+++ b/src/org/beanio/internal/parser/format/flat/FlatFieldFormatSupport.java
@@ -39,6 +39,7 @@ public abstract class FlatFieldFormatSupport implements FlatFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#insertValue(org.beanio.internal.parser.MarshallingContext, java.lang.Object)
      */
+    @Override
     public boolean insertValue(MarshallingContext context, Object value) {
         return false;
     }
@@ -48,6 +49,7 @@ public abstract class FlatFieldFormatSupport implements FlatFieldFormat {
      * @param context the {@link MarshallingContext} holding the record
      * @param text the field text to insert into the record
      */
+    @Override
     public void insertField(MarshallingContext context, String text) {
         boolean commit = text != null || !isLazy();
         
@@ -67,6 +69,7 @@ public abstract class FlatFieldFormatSupport implements FlatFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#extract(org.beanio.internal.parser.UnmarshallingContext, boolean)
      */
+    @Override
     public String extract(UnmarshallingContext context, boolean reporting) {
         String text = extractFieldText(context, reporting);
         
@@ -116,6 +119,7 @@ public abstract class FlatFieldFormatSupport implements FlatFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.flat.FlatFieldFormat#getPosition()
      */
+    @Override
     public int getPosition() {
         return position;
     }
@@ -132,6 +136,7 @@ public abstract class FlatFieldFormatSupport implements FlatFieldFormat {
         this.until = until;
     }
 
+    @Override
     public int getSize() {
         return 1;
     }
@@ -140,6 +145,7 @@ public abstract class FlatFieldFormatSupport implements FlatFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isNillable()
      */
+    @Override
     public boolean isNillable() {
         return false;
     }
@@ -164,6 +170,7 @@ public abstract class FlatFieldFormatSupport implements FlatFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isLazy()
      */
+    @Override
     public boolean isLazy() {
         return lazy;
     }

--- a/src/org/beanio/internal/parser/format/json/JsonFieldFormat.java
+++ b/src/org/beanio/internal/parser/format/json/JsonFieldFormat.java
@@ -59,6 +59,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * @see org.beanio.internal.parser.FieldFormat#extract(org.beanio.internal.parser.UnmarshallingContext, boolean)
      */
     @SuppressWarnings("unchecked")
+    @Override
     public String extract(UnmarshallingContext context, boolean reportErrors) {
         JsonUnmarshallingContext ctx = (JsonUnmarshallingContext) context;
     
@@ -137,6 +138,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#insertValue(org.beanio.internal.parser.MarshallingContext, java.lang.Object)
      */
+    @Override
     public boolean insertValue(MarshallingContext context, Object value) {
         if (!bypassTypeHandler) {
             return false;
@@ -161,6 +163,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#insertField(org.beanio.internal.parser.MarshallingContext, java.lang.String)
      */
+    @Override
     public void insertField(MarshallingContext context, String text) {
         
         JsonMarshallingContext ctx = (JsonMarshallingContext) context;
@@ -211,6 +214,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonType#getName()
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -235,6 +239,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#getSize()
      */
+    @Override
     public int getSize() {
         return 1;
     }
@@ -251,6 +256,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isNillable()
      */
+    @Override
     public boolean isNillable() {
         return nillable;
     }
@@ -259,6 +265,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isLazy()
      */
+    @Override
     public boolean isLazy() {
         return lazy;
     }
@@ -275,6 +282,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonType#getJsonName()
      */
+    @Override
     public String getJsonName() {
         return jsonName;
     }
@@ -291,6 +299,7 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonType#getJsonType()
      */
+    @Override
     public char getJsonType() {
         return jsonType;
     }
@@ -299,10 +308,12 @@ public class JsonFieldFormat implements FieldFormat, JsonNode {
         this.jsonArray = repeating;
     }
     
+    @Override
     public boolean isJsonArray() {
         return jsonArray;
     }
     
+    @Override
     public int getJsonArrayIndex() {
         return jsonArrayIndex;
     }

--- a/src/org/beanio/internal/parser/format/json/JsonMarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/json/JsonMarshallingContext.java
@@ -61,7 +61,7 @@ public class JsonMarshallingContext extends MarshallingContext {
             value = new LinkedHashMap<String,String>();
         }
         else { // array
-            value = new ArrayList<Object>();
+            value = new ArrayList<>();
         }
         
         put(type, value);
@@ -99,14 +99,14 @@ public class JsonMarshallingContext extends MarshallingContext {
                     list = (List<Object>) list().get(index);
                 }
                 else {
-                    list = new ArrayList<Object>();
+                    list = new ArrayList<>();
                     list().add(list);                    
                 }
             }
             else { // object
                 list = (List<Object>) map().get(type.getJsonName());
                 if (list == null) {
-                    list = new ArrayList<Object>();
+                    list = new ArrayList<>();
                     map().put(type.getJsonName(), list);
                 }
             }

--- a/src/org/beanio/internal/parser/format/json/JsonStreamFormat.java
+++ b/src/org/beanio/internal/parser/format/json/JsonStreamFormat.java
@@ -36,6 +36,7 @@ public class JsonStreamFormat extends StreamFormatSupport implements StreamForma
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createUnmarshallingContext()
      */
+    @Override
     public UnmarshallingContext createUnmarshallingContext() {
         return new JsonUnmarshallingContext(maxDepth);
     }
@@ -44,6 +45,7 @@ public class JsonStreamFormat extends StreamFormatSupport implements StreamForma
      * (non-Javadoc)
      * @see org.beanio.internal.parser.StreamFormat#createMarshallingContext(boolean)
      */
+    @Override
     public MarshallingContext createMarshallingContext(boolean streaming) {
         return new JsonMarshallingContext(maxDepth);
     }

--- a/src/org/beanio/internal/parser/format/json/JsonWrapper.java
+++ b/src/org/beanio/internal/parser/format/json/JsonWrapper.java
@@ -112,6 +112,7 @@ public class JsonWrapper extends DelegatingParser implements JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonNode#getJsonName()
      */
+    @Override
     public String getJsonName() {
         return jsonName;
     }
@@ -124,6 +125,7 @@ public class JsonWrapper extends DelegatingParser implements JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonNode#getJsonType()
      */
+    @Override
     public char getJsonType() {
         return jsonType;
     }
@@ -136,6 +138,7 @@ public class JsonWrapper extends DelegatingParser implements JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonNode#isJsonArray()
      */
+    @Override
     public boolean isJsonArray() {
         return jsonArray;
     }
@@ -148,6 +151,7 @@ public class JsonWrapper extends DelegatingParser implements JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonNode#getJsonArrayIndex()
      */
+    @Override
     public int getJsonArrayIndex() {
         return jsonArrayIndex;
     }
@@ -160,6 +164,7 @@ public class JsonWrapper extends DelegatingParser implements JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.json.JsonNode#isNillable()
      */
+    @Override
     public boolean isNillable() {
         return nillable;
     }
@@ -172,6 +177,7 @@ public class JsonWrapper extends DelegatingParser implements JsonNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.DelegatingParser#isLazy()
      */
+    @Override
     public boolean isOptional() {
         return optional;
     }

--- a/src/org/beanio/internal/parser/format/xml/XmlAttributeField.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlAttributeField.java
@@ -41,6 +41,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlFieldFormat#extractText(org.beanio.internal.parser.format.xml.XmlUnmarshallingContext)
      */
+    @Override
     public String extractText(XmlUnmarshallingContext context) {
         Element parent = context.getPosition();
         if (parent == null) {
@@ -55,6 +56,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlFieldFormat#insertText(org.beanio.internal.parser.format.xml.XmlMarshallingContext, java.lang.String)
      */
+    @Override
     public void insertText(XmlMarshallingContext ctx, String fieldText) {
         Element parent = (Element) ctx.getParent();
         
@@ -82,6 +84,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getType()
      */
+    @Override
     public int getType() {
         return XmlNode.XML_TYPE_ATTRIBUTE;
     }
@@ -90,6 +93,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getLocalName()
      */
+    @Override
     public String getLocalName() {
         return localName;
     }
@@ -106,6 +110,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getNamespace()
      */
+    @Override
     public String getNamespace() {
         return namespace;
     }
@@ -122,6 +127,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getPrefix()
      */
+    @Override
     public String getPrefix() {
         return prefix;
     }
@@ -138,6 +144,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isNamespaceAware()
      */
+    @Override
     public boolean isNamespaceAware() {
         return namespaceAware;
     }
@@ -154,6 +161,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isNillable()
      */
+    @Override
     public boolean isNillable() {
         return false;
     }
@@ -162,6 +170,7 @@ public class XmlAttributeField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isRepeating()
      */
+    @Override
     public boolean isRepeating() {
         return false;
     }

--- a/src/org/beanio/internal/parser/format/xml/XmlElementField.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlElementField.java
@@ -48,6 +48,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlFieldFormat#extractText(org.beanio.internal.parser.format.xml.XmlUnmarshallingContext)
      */
+    @Override
     public String extractText(XmlUnmarshallingContext context) {
         Element node = context.findElement(this);
         if (node == null) {
@@ -70,6 +71,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlFieldFormat#insertText(org.beanio.internal.parser.format.xml.XmlMarshallingContext, java.lang.String)
      */
+    @Override
     public void insertText(XmlMarshallingContext ctx, String fieldText) {
         if (fieldText == null && isLazy()) {
             return;
@@ -108,6 +110,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isRepeating()
      */
+    @Override
     public boolean isRepeating() {
         return repeating;
     }
@@ -124,6 +127,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getType()
      */
+    @Override
     public int getType() {
         return XmlNode.XML_TYPE_ELEMENT;
     }
@@ -132,6 +136,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getLocalName()
      */
+    @Override
     public String getLocalName() {
         return localName;
     }
@@ -148,6 +153,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getNamespace()
      */
+    @Override
     public String getNamespace() {
         return namespace;
     }
@@ -164,6 +170,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getPrefix()
      */
+    @Override
     public String getPrefix() {
         return prefix;
     }
@@ -180,6 +187,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isNillable()
      */
+    @Override
     public boolean isNillable() {
         return nillable;
     }
@@ -196,6 +204,7 @@ public class XmlElementField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isNamespaceAware()
      */
+    @Override
     public boolean isNamespaceAware() {
         return namespaceAware;
     }

--- a/src/org/beanio/internal/parser/format/xml/XmlFieldFormat.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlFieldFormat.java
@@ -40,6 +40,7 @@ public abstract class XmlFieldFormat implements FieldFormat, XmlNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#insertValue(org.beanio.internal.parser.MarshallingContext, java.lang.Object)
      */
+    @Override
     public boolean insertValue(MarshallingContext context, Object value) {
         return false;
     }
@@ -48,6 +49,7 @@ public abstract class XmlFieldFormat implements FieldFormat, XmlNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#insertField(org.beanio.internal.parser.MarshallingContext, java.lang.String)
      */
+    @Override
     public void insertField(MarshallingContext context, String fieldText) {
         XmlMarshallingContext ctx = (XmlMarshallingContext) context;
         
@@ -69,6 +71,7 @@ public abstract class XmlFieldFormat implements FieldFormat, XmlNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#extract(org.beanio.internal.parser.UnmarshallingContext, boolean)
      */
+    @Override
     public String extract(UnmarshallingContext context, boolean reportErrors) {
         XmlUnmarshallingContext ctx = (XmlUnmarshallingContext) context;
         
@@ -107,6 +110,7 @@ public abstract class XmlFieldFormat implements FieldFormat, XmlNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#getSize()
      */
+    @Override
     public int getSize() {
         return 1;
     }
@@ -131,6 +135,7 @@ public abstract class XmlFieldFormat implements FieldFormat, XmlNode {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isLazy()
      */
+    @Override
     public boolean isLazy() {
         return lazy;
     }

--- a/src/org/beanio/internal/parser/format/xml/XmlSelectorWrapper.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlSelectorWrapper.java
@@ -34,7 +34,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
     private static final String WRITTEN_KEY = "written";
     
     /* state attributes */
-    private ParserLocal<Boolean> written = new ParserLocal<Boolean>(false);
+    private ParserLocal<Boolean> written = new ParserLocal<>(false);
     
     /* marshalling flags */
     private boolean group;

--- a/src/org/beanio/internal/parser/format/xml/XmlSelectorWrapper.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlSelectorWrapper.java
@@ -96,6 +96,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.parser2.Marshaller#marshal(org.beanio.parser2.MarshallingContext)
      */
+    @Override
     public boolean marshal(MarshallingContext context) throws IOException {
         XmlMarshallingContext ctx = (XmlMarshallingContext) context;
         
@@ -133,6 +134,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#unmarshal(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public boolean unmarshal(UnmarshallingContext context) {
         return getDelegate().unmarshal(context);
     }
@@ -141,6 +143,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#skip(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public void skip(UnmarshallingContext context) {
         getDelegate().skip(context);
     }
@@ -149,6 +152,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchNextBean(org.beanio.internal.parser.MarshallingContext, java.lang.Object)
      */
+    @Override
     public Selector matchNext(MarshallingContext context) {
         XmlMarshallingContext ctx = (XmlMarshallingContext) context;
         
@@ -196,6 +200,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchNext(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public Selector matchNext(UnmarshallingContext context) {
         return match(context, true);
     }
@@ -204,6 +209,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#matchAny(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public Selector matchAny(UnmarshallingContext context) {
         return match(context, false);
     }
@@ -261,6 +267,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#matches(org.beanio.internal.parser.UnmarshallingContext)
      */
+    @Override
     public boolean matches(UnmarshallingContext context) {
         // a group is never used to match a record
         return false;
@@ -273,6 +280,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * @param state the Map to update with the latest state
      * @since 1.2
      */
+    @Override
     public void updateState(ParsingContext context, String namespace, Map<String, Object> state) {
         state.put(getKey(namespace, WRITTEN_KEY), written.get(context));
         
@@ -289,6 +297,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * @param state the Map containing the state to restore
      * @since 1.2
      */
+    @Override
     public void restoreState(ParsingContext context, String namespace, Map<String, Object> state) {
         String key = getKey(namespace, WRITTEN_KEY); 
         Boolean written = (Boolean) state.get(key);
@@ -325,6 +334,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#getValue()
      */
+    @Override
     public Object getValue(ParsingContext context) {
         return getDelegate().getValue(context);
     }
@@ -333,6 +343,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#setValue(java.lang.Object)
      */
+    @Override
     public void setValue(ParsingContext context, Object value) {
         getDelegate().setValue(context, value);
     }
@@ -341,6 +352,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#getSize()
      */
+    @Override
     public int getSize() {
         return getDelegate().getSize();
     }
@@ -349,6 +361,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#close(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public Selector close(ParsingContext context) {
         return getDelegate().close(context);
     }
@@ -357,6 +370,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#reset(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public void reset(ParsingContext context) {
         written.set(context, false);
         getDelegate().reset(context);
@@ -366,6 +380,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getCount(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public int getCount(ParsingContext context) {
         return getDelegate().getCount(context);
     }
@@ -374,6 +389,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#setCount(org.beanio.internal.parser.ParsingContext, int)
      */
+    @Override
     public void setCount(ParsingContext context, int count) {
         getDelegate().setCount(context, count);
     }
@@ -382,6 +398,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getMinOccurs()
      */
+    @Override
     public int getMinOccurs() {
         return getDelegate().getMinOccurs();
     }
@@ -390,6 +407,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getMaxOccurs()
      */
+    @Override
     public int getMaxOccurs() {
         return getDelegate().getMaxOccurs();
     }
@@ -398,6 +416,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getOrder()
      */
+    @Override
     public int getOrder() {
         return getDelegate().getOrder();
     }
@@ -406,6 +425,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#isMaxOccursReached(org.beanio.internal.parser.ParsingContext)
      */
+    @Override
     public boolean isMaxOccursReached(ParsingContext context) {
         return getDelegate().isMaxOccursReached(context);
     }
@@ -414,6 +434,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#clearValue()
      */
+    @Override
     public void clearValue(ParsingContext context) {
         getDelegate().clearValue(context);
     }
@@ -422,6 +443,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#isIdentifier()
      */
+    @Override
     public boolean isIdentifier() {
         return getDelegate().isIdentifier();
     }
@@ -439,6 +461,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#isLazy()
      */
+    @Override
     public boolean isOptional() {
         return getDelegate().isOptional();
     }
@@ -447,6 +470,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getLocalName()
      */
+    @Override
     public String getLocalName() {
         return localName;
     }
@@ -461,6 +485,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getNamespace()
      */
+    @Override
     public String getNamespace() {
         return namespace;
     }
@@ -477,6 +502,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getPrefix()
      */
+    @Override
     public String getPrefix() {
         return prefix;
     }
@@ -493,6 +519,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isNamespaceAware()
      */
+    @Override
     public boolean isNamespaceAware() {
         return namespaceAware;
     }
@@ -509,6 +536,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getType()
      */
+    @Override
     public int getType() {
         return XmlNode.XML_TYPE_ELEMENT;
     }
@@ -517,6 +545,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isNillable()
      */
+    @Override
     public boolean isNillable() {
         return false;
     }
@@ -525,6 +554,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isRepeating()
      */
+    @Override
     public boolean isRepeating() {
         return false;
     }
@@ -533,6 +563,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#getProperty()
      */
+    @Override
     public Property getProperty() {
         return getDelegate().getProperty();
     }
@@ -541,6 +572,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Parser#hasContent()
      */
+    @Override
     public boolean hasContent(ParsingContext context) {
         return getDelegate().hasContent(context);
     }
@@ -549,6 +581,7 @@ public class XmlSelectorWrapper extends ParserComponent implements Selector, Xml
      * (non-Javadoc)
      * @see org.beanio.internal.parser.Selector#isRecordGroup()
      */
+    @Override
     public boolean isRecordGroup() {
         return false;
     }

--- a/src/org/beanio/internal/parser/format/xml/XmlStreamFormat.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlStreamFormat.java
@@ -47,6 +47,7 @@ public class XmlStreamFormat extends StreamFormatSupport {
      * (non-Javadoc)
      * @see org.beanio.parser2.StreamFormat#createUnmarshallingContext()
      */
+    @Override
     public UnmarshallingContext createUnmarshallingContext() {
         return new XmlUnmarshallingContext(groupDepth);
     }
@@ -55,6 +56,7 @@ public class XmlStreamFormat extends StreamFormatSupport {
      * (non-Javadoc)
      * @see org.beanio.parser2.StreamFormat#createMarshallingContext()
      */
+    @Override
     public MarshallingContext createMarshallingContext(boolean streaming) {
         XmlMarshallingContext ctx = new XmlMarshallingContext(groupDepth);
         ctx.setStreaming(streaming);
@@ -65,6 +67,7 @@ public class XmlStreamFormat extends StreamFormatSupport {
     public void setRecordParserFactory(RecordParserFactory recordParserFactory) {
         if (recordParserFactory != null && recordParserFactory instanceof XmlStreamConfigurationAware) {
             ((XmlStreamConfigurationAware)recordParserFactory).setConfiguration(new XmlStreamConfiguration() {
+                @Override
                 public Document getDocument() {
                     return createBaseDocument(layout);
                 }

--- a/src/org/beanio/internal/parser/format/xml/XmlTextField.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlTextField.java
@@ -60,6 +60,7 @@ public class XmlTextField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getType()
      */
+    @Override
     public int getType() {
         return XmlNode.XML_TYPE_TEXT;
     }
@@ -68,6 +69,7 @@ public class XmlTextField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.FieldFormat#isNillable()
      */
+    @Override
     public boolean isNillable() {
         return false;
     }
@@ -76,6 +78,7 @@ public class XmlTextField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getLocalName()
      */
+    @Override
     public String getLocalName() {
         return null;
     }
@@ -84,6 +87,7 @@ public class XmlTextField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getNamespace()
      */
+    @Override
     public String getNamespace() {
         return null;
     }
@@ -92,6 +96,7 @@ public class XmlTextField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#isNamespaceAware()
      */
+    @Override
     public boolean isNamespaceAware() {
         return false;
     }
@@ -100,10 +105,12 @@ public class XmlTextField extends XmlFieldFormat {
      * (non-Javadoc)
      * @see org.beanio.internal.parser.format.xml.XmlNode#getPrefix()
      */
+    @Override
     public String getPrefix() {
         return null;
     }
     
+    @Override
     public boolean isRepeating() {
         return false;
     }

--- a/src/org/beanio/internal/parser/format/xml/XmlUnmarshallingContext.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlUnmarshallingContext.java
@@ -35,7 +35,7 @@ public class XmlUnmarshallingContext extends UnmarshallingContext {
     /* The last parsed node in the document, which is the parent node of the next field/bean to parse */
     private Element position;
     /* This stack of elements is used to store the last XML node parsed for a field or bean collection. */
-    private LinkedList<Element> elementStack = new LinkedList<Element>();
+    private LinkedList<Element> elementStack = new LinkedList<>();
     /* Store previously matched groups for parsing subsequent records in a record group */
     private XmlNode[] groupStack;
     

--- a/src/org/beanio/internal/parser/format/xml/XmlWrapper.java
+++ b/src/org/beanio/internal/parser/format/xml/XmlWrapper.java
@@ -134,6 +134,7 @@ public class XmlWrapper extends DelegatingParser implements XmlNode {
         return true;
     }
 
+    @Override
     public String getLocalName() {
         return localName;
     }
@@ -142,6 +143,7 @@ public class XmlWrapper extends DelegatingParser implements XmlNode {
         this.localName = localName;
     }
 
+    @Override
     public String getPrefix() {
         return prefix;
     }
@@ -150,6 +152,7 @@ public class XmlWrapper extends DelegatingParser implements XmlNode {
         this.prefix = prefix;
     }
 
+    @Override
     public String getNamespace() {
         return namespace;
     }
@@ -158,6 +161,7 @@ public class XmlWrapper extends DelegatingParser implements XmlNode {
         this.namespace = namespace;
     }
 
+    @Override
     public boolean isNamespaceAware() {
         return namespaceAware;
     }
@@ -166,6 +170,7 @@ public class XmlWrapper extends DelegatingParser implements XmlNode {
         this.namespaceAware = namespaceAware;
     }
 
+    @Override
     public boolean isNillable() {
         return nillable;
     }
@@ -174,10 +179,12 @@ public class XmlWrapper extends DelegatingParser implements XmlNode {
         this.nillable = nillable;
     }
 
+    @Override
     public int getType() {
         return XmlNode.XML_TYPE_ELEMENT;
     }
     
+    @Override
     public boolean isRepeating() {
         return repeating;
     }
@@ -186,6 +193,7 @@ public class XmlWrapper extends DelegatingParser implements XmlNode {
         this.repeating = repeating;
     }
     
+    @Override
     public boolean isOptional() {
         return lazy;
     }

--- a/src/org/beanio/internal/parser/message/ResourceBundleMessageFactory.java
+++ b/src/org/beanio/internal/parser/message/ResourceBundleMessageFactory.java
@@ -37,7 +37,7 @@ public class ResourceBundleMessageFactory implements MessageFactory {
     /* default resource bundle for messages based on the stream format */
     private ResourceBundle defaultResourceBundle;
     /* cache messages from resource bundles */
-    private ConcurrentHashMap<String, String> messageCache = new ConcurrentHashMap<String, String>();
+    private ConcurrentHashMap<String, String> messageCache = new ConcurrentHashMap<>();
     /* used to flag cache misses */
     private static final String NOT_FOUND = new String();
     

--- a/src/org/beanio/internal/parser/message/ResourceBundleMessageFactory.java
+++ b/src/org/beanio/internal/parser/message/ResourceBundleMessageFactory.java
@@ -47,6 +47,7 @@ public class ResourceBundleMessageFactory implements MessageFactory {
      * (non-Javadoc)
      * @see org.beanio.parser.MessageContext#getRecordLabel(java.lang.String)
      */
+    @Override
     public String getRecordLabel(String recordName) {
         return getLabel(LABEL_MESSAGE_PREFIX + "." + recordName);
     }
@@ -55,6 +56,7 @@ public class ResourceBundleMessageFactory implements MessageFactory {
      * (non-Javadoc)
      * @see org.beanio.parser.MessageContext#getFieldLabel(java.lang.String, java.lang.String)
      */
+    @Override
     public String getFieldLabel(String recordName, String fieldName) {
         return getLabel(LABEL_MESSAGE_PREFIX + "." + recordName + "." + fieldName);
     }
@@ -87,6 +89,7 @@ public class ResourceBundleMessageFactory implements MessageFactory {
      * (non-Javadoc)
      * @see org.bio.context.MessageContext#getFieldErrorMessage(java.lang.String, java.lang.String, java.lang.String)
      */
+    @Override
     public String getFieldErrorMessage(String recordName, String fieldName, String rule) {
         String key = FIELD_ERROR_MESSAGE_PREFIX + "." + recordName + "." + fieldName + "." + rule;
 
@@ -126,6 +129,7 @@ public class ResourceBundleMessageFactory implements MessageFactory {
      * (non-Javadoc)
      * @see org.bio.context.MessageContext#getRecordErrorMessage(java.lang.String, java.lang.String)
      */
+    @Override
     public String getRecordErrorMessage(String recordName, String rule) {
         String key = RECORD_ERROR_MESSAGE_PREFIX + "." + recordName + "." + rule;
 

--- a/src/org/beanio/internal/util/BeanUtil.java
+++ b/src/org/beanio/internal/util/BeanUtil.java
@@ -330,7 +330,7 @@ public class BeanUtil {
             
             boolean escaped = false;
             StringBuilder item = new StringBuilder();
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             
             char[] ca = text.toCharArray();
             for (char c : ca) {

--- a/src/org/beanio/internal/util/BeanUtil.java
+++ b/src/org/beanio/internal/util/BeanUtil.java
@@ -177,6 +177,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#parse(java.lang.String)
          */
+        @Override
         public Character parse(String text) throws TypeConversionException {
             if (text == null) {
                 return null;
@@ -211,6 +212,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#format(java.lang.Object)
          */
+        @Override
         public String format(Object value) {
             throw new UnsupportedOperationException();
         }
@@ -219,6 +221,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#getType()
          */
+        @Override
         public Class<?> getType() {
             return Character.class;
         }
@@ -234,6 +237,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#parse(java.lang.String)
          */
+        @Override
         public String parse(String text) throws TypeConversionException {
             if (text == null) {
                 return text;
@@ -295,6 +299,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#format(java.lang.Object)
          */
+        @Override
         public String format(Object value) {
             throw new UnsupportedOperationException();
         }
@@ -303,6 +308,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#getType()
          */
+        @Override
         public Class<?> getType() {
             return String.class;
         }
@@ -318,6 +324,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#parse(java.lang.String)
          */
+        @Override
         public String[] parse(String text) throws TypeConversionException {
             if (text == null || "".equals(text)) {
                 return null;
@@ -360,6 +367,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#format(java.lang.Object)
          */
+        @Override
         public String format(Object value) {
             throw new UnsupportedOperationException();
         }
@@ -368,6 +376,7 @@ public class BeanUtil {
          * (non-Javadoc)
          * @see org.beanio.types.TypeHandler#getType()
          */
+        @Override
         public Class<?> getType() {
             return String[].class;
         }

--- a/src/org/beanio/internal/util/DebugUtil.java
+++ b/src/org/beanio/internal/util/DebugUtil.java
@@ -1,6 +1,7 @@
 package org.beanio.internal.util;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import org.beanio.internal.parser.format.FieldPadding;
 
@@ -45,13 +46,8 @@ public class DebugUtil {
     }
     
     public static String toString(Debuggable c) {
-        try {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            c.debug(new PrintStream(out));
-            return new String(out.toByteArray(), "ASCII");
-        }
-        catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        c.debug(new PrintStream(out));
+        return new String(out.toByteArray(), StandardCharsets.US_ASCII);
     }
 }

--- a/src/org/beanio/internal/util/EnumTypeHandler.java
+++ b/src/org/beanio/internal/util/EnumTypeHandler.java
@@ -26,6 +26,7 @@ public class EnumTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#parse(java.lang.String)
      */
+    @Override
     public Object parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text)) {
             return null;
@@ -43,6 +44,7 @@ public class EnumTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#format(java.lang.Object)
      */
+    @Override
     public String format(Object value) {
         if (value == null) {
             return null;
@@ -54,6 +56,7 @@ public class EnumTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return type;
     }

--- a/src/org/beanio/internal/util/JsonUtil.java
+++ b/src/org/beanio/internal/util/JsonUtil.java
@@ -75,12 +75,12 @@ public class JsonUtil {
             return d;
         } 
         else if (text.length() < INT_SIZE) {
-            return new Integer(text);
+            return Integer.valueOf(text);
         }
         else {
             Long n = new Long(text);
             if (n.intValue() == n.longValue()) {
-                return new Integer(n.intValue());
+                return Integer.valueOf(n.intValue());
             }
             return n;
         }

--- a/src/org/beanio/internal/util/Replicator.java
+++ b/src/org/beanio/internal/util/Replicator.java
@@ -30,7 +30,7 @@ import java.util.*;
  */
 public class Replicator {
 
-    private Set<Replicateable> archetypes = new HashSet<Replicateable>();
+    private Set<Replicateable> archetypes = new HashSet<>();
     
     /**
      * Constructs a new <tt>Replicator</tt>.
@@ -61,7 +61,7 @@ public class Replicator {
         }
         
         // create a map of archetypes --> clones, aka old reference --> new reference
-        IdentityHashMap<Object, Object> clones = new IdentityHashMap<Object, Object>();
+        IdentityHashMap<Object, Object> clones = new IdentityHashMap<>();
         
         // clone all registered archetypes and add their reference to the map
         for (Replicateable archetype : archetypes) {

--- a/src/org/beanio/internal/util/ReplicatorTest.java
+++ b/src/org/beanio/internal/util/ReplicatorTest.java
@@ -65,7 +65,7 @@ public class ReplicatorTest {
     
     @SuppressWarnings("rawtypes")
     private static TreeNode createNode(String name) {
-        TreeNode<TreeNode> node = new TreeNode<TreeNode>();
+        TreeNode<TreeNode> node = new TreeNode<>();
         node.setName(name);
         replicator.register(node);
         return node;

--- a/src/org/beanio/internal/util/StringUtil.java
+++ b/src/org/beanio/internal/util/StringUtil.java
@@ -58,6 +58,7 @@ public final class StringUtil {
         throws IllegalArgumentException
     {
         return doPropertySubstitution(text, new PropertySource() {
+            @Override
             public String getProperty(String key) {
                 return properties != null ? properties.getProperty(key) : null;
             }

--- a/src/org/beanio/internal/util/ToStringEnumTypeHandler.java
+++ b/src/org/beanio/internal/util/ToStringEnumTypeHandler.java
@@ -24,7 +24,7 @@ public class ToStringEnumTypeHandler implements TypeHandler {
     public ToStringEnumTypeHandler(Class<Enum> type) {
         this.type = type;
         
-        map = new HashMap<String,Enum>();
+        map = new HashMap<>();
         
         Enum[] values = type.getEnumConstants();
         for (Enum value : values) {

--- a/src/org/beanio/internal/util/ToStringEnumTypeHandler.java
+++ b/src/org/beanio/internal/util/ToStringEnumTypeHandler.java
@@ -36,6 +36,7 @@ public class ToStringEnumTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#parse(java.lang.String)
      */
+    @Override
     public Object parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text)) {
             return null;
@@ -53,6 +54,7 @@ public class ToStringEnumTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#format(java.lang.Object)
      */
+    @Override
     public String format(Object value) {
         if (value == null) {
             return null;
@@ -64,6 +66,7 @@ public class ToStringEnumTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return type;
     }

--- a/src/org/beanio/internal/util/TreeNode.java
+++ b/src/org/beanio/internal/util/TreeNode.java
@@ -137,6 +137,7 @@ public class TreeNode<T extends TreeNode> implements Replicateable, Iterable<T> 
      * (non-Javadoc)
      * @see java.lang.Iterable#iterator()
      */
+    @Override
     public Iterator<T> iterator() {
         //assert children != null;
         return getChildren().iterator();
@@ -207,6 +208,7 @@ public class TreeNode<T extends TreeNode> implements Replicateable, Iterable<T> 
      * @see java.lang.Object#clone()
      */
     @SuppressWarnings("unchecked")
+    @Override
     public T clone() {
         try {
             return (T) super.clone();
@@ -221,6 +223,7 @@ public class TreeNode<T extends TreeNode> implements Replicateable, Iterable<T> 
      * @see org.beanio.parser2.util.Replicateable#updateReferences(java.util.Map)
      */
     @SuppressWarnings("unchecked")
+    @Override
     public void updateReferences(Map<Object, Object> map) {
         if (children == null) {
             return;

--- a/src/org/beanio/internal/util/TreeNode.java
+++ b/src/org/beanio/internal/util/TreeNode.java
@@ -54,10 +54,10 @@ public class TreeNode<T extends TreeNode> implements Replicateable, Iterable<T> 
             children = null;
         }
         else if (size < 0 || size > 10) {
-            children = new ArrayList<T>();
+            children = new ArrayList<>();
         }
         else {
-            children = new ArrayList<T>(size);
+            children = new ArrayList<>(size);
         }
     }
     
@@ -158,7 +158,7 @@ public class TreeNode<T extends TreeNode> implements Replicateable, Iterable<T> 
      */
     public void add(T child) throws IllegalArgumentException {
         if (children == null) {
-            children = new ArrayList<T>();
+            children = new ArrayList<>();
         }
         
         if (isSupportedChild(child)) {
@@ -230,7 +230,7 @@ public class TreeNode<T extends TreeNode> implements Replicateable, Iterable<T> 
             return;
         }
         
-        List<T> list = new ArrayList<T>(children.size());
+        List<T> list = new ArrayList<>(children.size());
         for (T node : children) {
             list.add((T) map.get(node));
         }

--- a/src/org/beanio/internal/util/TypeHandlerFactory.java
+++ b/src/org/beanio/internal/util/TypeHandlerFactory.java
@@ -55,7 +55,7 @@ public class TypeHandlerFactory {
 
     private TypeHandlerFactory parent;
     private ClassLoader classLoader;
-    private Map<String, TypeHandler> handlerMap = new HashMap<String, TypeHandler>();
+    private Map<String, TypeHandler> handlerMap = new HashMap<>();
 
     private static final String NAME_KEY = "name:";
     private static final String TYPE_KEY = "type:";

--- a/src/org/beanio/internal/util/TypeHandlerFactory.java
+++ b/src/org/beanio/internal/util/TypeHandlerFactory.java
@@ -83,12 +83,14 @@ public class TypeHandlerFactory {
             settings.getProperty(Settings.DEFAULT_DATETIME_FORMAT)));
         defaultFactory.registerHandlerFor(TypeUtil.DATE_ALIAS, new DateTypeHandler(
             settings.getProperty(Settings.DEFAULT_DATE_FORMAT)) {
+            @Override
             protected DateFormat createDefaultDateFormat() {
                 return DateFormat.getDateInstance(DateFormat.DEFAULT, locale);
             }
         });
         defaultFactory.registerHandlerFor(TypeUtil.TIME_ALIAS, new DateTypeHandler(
             settings.getProperty(Settings.DEFAULT_TIME_FORMAT)) {
+            @Override
             protected DateFormat createDefaultDateFormat() {
                 return DateFormat.getTimeInstance(DateFormat.DEFAULT, locale);
             }
@@ -98,12 +100,14 @@ public class TypeHandlerFactory {
             settings.getProperty(Settings.DEFAULT_DATETIME_FORMAT)));
         defaultFactory.registerHandlerFor(TypeUtil.CALENDAR_DATE_ALIAS, new CalendarTypeHandler(
             settings.getProperty(Settings.DEFAULT_DATE_FORMAT)) {
+            @Override
             protected DateFormat createDefaultDateFormat() {
                 return DateFormat.getDateInstance(DateFormat.DEFAULT, locale);
             }
         });
         defaultFactory.registerHandlerFor(TypeUtil.CALENDAR_TIME_ALIAS, new CalendarTypeHandler(
             settings.getProperty(Settings.DEFAULT_TIME_FORMAT)) {
+            @Override
             protected DateFormat createDefaultDateFormat() {
                 return DateFormat.getTimeInstance(DateFormat.DEFAULT, locale);
             }

--- a/src/org/beanio/stream/RecordParserFactorySupport.java
+++ b/src/org/beanio/stream/RecordParserFactorySupport.java
@@ -26,20 +26,25 @@ import java.io.*;
  */
 public class RecordParserFactorySupport implements RecordParserFactory {
 
+    @Override
     public void init() throws IllegalArgumentException { }
 
+    @Override
     public RecordReader createReader(Reader in) throws IllegalArgumentException {
         throw new UnsupportedOperationException("BeanReader not supported");
     }
 
+    @Override
     public RecordWriter createWriter(Writer out) throws IllegalArgumentException {
         throw new UnsupportedOperationException("BeanWriter not supported");
     }
 
+    @Override
     public RecordMarshaller createMarshaller() throws IllegalArgumentException {
         throw new UnsupportedOperationException("Marshaller not supported");
     }
 
+    @Override
     public RecordUnmarshaller createUnmarshaller() throws IllegalArgumentException {
         throw new UnsupportedOperationException("Unmarshaller not supported");
     }

--- a/src/org/beanio/stream/csv/CsvReader.java
+++ b/src/org/beanio/stream/csv/CsvReader.java
@@ -121,6 +121,7 @@ public class CsvReader implements RecordReader {
      * -1 is returned if the end of the stream was reached.
      * @return the starting line number of the last record
      */
+    @Override
     public int getRecordLineNumber() {
         return recordLineNumber;
     }
@@ -130,6 +131,7 @@ public class CsvReader implements RecordReader {
      * stream was reached.
      * @return the raw text of the last record
      */
+    @Override
     public String getRecordText() {
         return recordText;
     }
@@ -140,6 +142,7 @@ public class CsvReader implements RecordReader {
      *   read from the stream
      * @throws IOException if an I/O error occurs
      */
+    @Override
     public String[] read() throws IOException, RecordIOException {
         // fieldList is set to null when the end of stream is reached
         if (fieldList == null) {
@@ -430,6 +433,7 @@ public class CsvReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#close()
      */
+    @Override
     public void close() throws IOException {
         in.close();
     }

--- a/src/org/beanio/stream/csv/CsvReader.java
+++ b/src/org/beanio/stream/csv/CsvReader.java
@@ -62,7 +62,7 @@ public class CsvReader implements RecordReader {
     private transient int recordLineNumber;
     private transient int lineNumber = 0;
     private transient boolean skipLF = false;
-    private transient List<String> fieldList = new ArrayList<String>();
+    private transient List<String> fieldList = new ArrayList<>();
     
     /**
      * Constructs a new <tt>CsvReader</tt>.

--- a/src/org/beanio/stream/csv/CsvRecordParser.java
+++ b/src/org/beanio/stream/csv/CsvRecordParser.java
@@ -37,7 +37,7 @@ public class CsvRecordParser implements RecordMarshaller, RecordUnmarshaller {
     private boolean unquotedQuotesAllowed = false;
     private boolean alwaysQuote = false;
     
-    private List<String> fieldList = new ArrayList<String>();
+    private List<String> fieldList = new ArrayList<>();
     
     /**
      * Constructs a new <tt>CsvRecordParser</tt>.

--- a/src/org/beanio/stream/csv/CsvRecordParser.java
+++ b/src/org/beanio/stream/csv/CsvRecordParser.java
@@ -87,6 +87,7 @@ public class CsvRecordParser implements RecordMarshaller, RecordUnmarshaller {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParser#parse(java.lang.String)
      */
+    @Override
     public Object unmarshal(String text) throws RecordIOException {
         fieldList.clear();
         
@@ -222,6 +223,7 @@ public class CsvRecordParser implements RecordMarshaller, RecordUnmarshaller {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordMarshaller#marshal(java.lang.Object)
      */
+    @Override
     public String marshal(Object record) {
         return marshal((String[])record);
     }

--- a/src/org/beanio/stream/csv/CsvRecordParserFactory.java
+++ b/src/org/beanio/stream/csv/CsvRecordParserFactory.java
@@ -36,6 +36,7 @@ public class CsvRecordParserFactory extends CsvParserConfiguration implements Re
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#init()
      */
+    @Override
     public void init() throws IllegalArgumentException {
         
         if (getQuote() == getDelimiter()) {
@@ -53,6 +54,7 @@ public class CsvRecordParserFactory extends CsvParserConfiguration implements Re
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReaderFactory#createReader(java.io.Reader)
      */
+    @Override
     public RecordReader createReader(Reader in) throws IllegalArgumentException {
         return new CsvReader(in, this);
     }
@@ -61,6 +63,7 @@ public class CsvRecordParserFactory extends CsvParserConfiguration implements Re
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriterFactory#createWriter(java.io.Writer)
      */
+    @Override
     public RecordWriter createWriter(Writer out) throws IllegalArgumentException {
         return new CsvWriter(out, this);
     }
@@ -69,6 +72,7 @@ public class CsvRecordParserFactory extends CsvParserConfiguration implements Re
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createMarshaller()
      */
+    @Override
     public RecordMarshaller createMarshaller() throws IllegalArgumentException {
         return new CsvRecordParser(this);
     }
@@ -77,6 +81,7 @@ public class CsvRecordParserFactory extends CsvParserConfiguration implements Re
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createUnmarshaller()
      */
+    @Override
     public RecordUnmarshaller createUnmarshaller() throws IllegalArgumentException {
         return new CsvRecordParser(this);
     }

--- a/src/org/beanio/stream/csv/CsvWriter.java
+++ b/src/org/beanio/stream/csv/CsvWriter.java
@@ -94,6 +94,7 @@ public class CsvWriter implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#write(java.lang.Object)
      */
+    @Override
     public void write(Object value) throws IOException {
     	write((String[])value);
     }
@@ -172,6 +173,7 @@ public class CsvWriter implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#flush()
      */
+    @Override
     public void flush() throws IOException {
         out.flush();
     }
@@ -180,6 +182,7 @@ public class CsvWriter implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#close()
      */
+    @Override
     public void close() throws IOException {
         out.close();
     }

--- a/src/org/beanio/stream/delimited/DelimitedReader.java
+++ b/src/org/beanio/stream/delimited/DelimitedReader.java
@@ -68,7 +68,7 @@ public class DelimitedReader implements RecordReader {
     private transient int recordLineNumber;
     private transient int lineNumber = 0;
     private transient boolean skipLF = false;
-    private transient List<String> fieldList = new ArrayList<String>();
+    private transient List<String> fieldList = new ArrayList<>();
 
     /**
      * Constructs a new <tt>DelimitedReader</tt> using a tab character for

--- a/src/org/beanio/stream/delimited/DelimitedReader.java
+++ b/src/org/beanio/stream/delimited/DelimitedReader.java
@@ -156,6 +156,7 @@ public class DelimitedReader implements RecordReader {
      * not terminated by new line characters.
      * @return the starting line number of the last record
      */
+    @Override
     public int getRecordLineNumber() {
         if (recordLineNumber < 0)
             return -1;
@@ -168,6 +169,7 @@ public class DelimitedReader implements RecordReader {
      * stream was reached.
      * @return the raw text of the last record
      */
+    @Override
     public String getRecordText() {
         return recordText;
     }
@@ -176,6 +178,7 @@ public class DelimitedReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#read()
      */
+    @Override
     public String[] read() throws IOException {
         // fieldList is set to null when the end of stream is reached
         if (fieldList == null) {
@@ -355,6 +358,7 @@ public class DelimitedReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#close()
      */
+    @Override
     public void close() throws IOException {
         in.close();
     }

--- a/src/org/beanio/stream/delimited/DelimitedRecordParser.java
+++ b/src/org/beanio/stream/delimited/DelimitedRecordParser.java
@@ -65,6 +65,7 @@ public class DelimitedRecordParser implements RecordUnmarshaller, RecordMarshall
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParser#parse(java.lang.String)
      */
+    @Override
     public String[] unmarshal(String text) {
         fieldList.clear();
         
@@ -110,6 +111,7 @@ public class DelimitedRecordParser implements RecordUnmarshaller, RecordMarshall
      * (non-Javadoc)
      * @see org.beanio.stream.RecordMarshaller#marshal(java.lang.Object)
      */
+    @Override
     public String marshal(Object record) {
         return marshal((String[]) record);
     }

--- a/src/org/beanio/stream/delimited/DelimitedRecordParser.java
+++ b/src/org/beanio/stream/delimited/DelimitedRecordParser.java
@@ -32,7 +32,7 @@ public class DelimitedRecordParser implements RecordUnmarshaller, RecordMarshall
     private char escape;
     private boolean escapeEnabled;
     
-    private List<String> fieldList = new ArrayList<String>();
+    private List<String> fieldList = new ArrayList<>();
     
     /**
      * Constructs a new <tt>DelimitedRecordParser</tt>.

--- a/src/org/beanio/stream/delimited/DelimitedRecordParserFactory.java
+++ b/src/org/beanio/stream/delimited/DelimitedRecordParserFactory.java
@@ -36,6 +36,7 @@ public class DelimitedRecordParserFactory  extends DelimitedParserConfiguration 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#init()
      */
+    @Override
     public void init() throws IllegalArgumentException {
         
         if (getEscape() != null && getEscape() == getDelimiter()) {
@@ -52,6 +53,7 @@ public class DelimitedRecordParserFactory  extends DelimitedParserConfiguration 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReaderFactory#createReader(java.io.Reader)
      */
+    @Override
     public RecordReader createReader(Reader in) throws IllegalArgumentException {
         return new DelimitedReader(in, this);
     }
@@ -60,6 +62,7 @@ public class DelimitedRecordParserFactory  extends DelimitedParserConfiguration 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriterFactory#createWriter(java.io.Writer)
      */
+    @Override
     public RecordWriter createWriter(Writer out) throws IllegalArgumentException {
         return new DelimitedWriter(out, this);
     }
@@ -68,6 +71,7 @@ public class DelimitedRecordParserFactory  extends DelimitedParserConfiguration 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createMarshaller()
      */
+    @Override
     public RecordMarshaller createMarshaller() throws IllegalArgumentException {
         return new DelimitedRecordParser(this);
     }
@@ -76,6 +80,7 @@ public class DelimitedRecordParserFactory  extends DelimitedParserConfiguration 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createUnmarshaller()
      */
+    @Override
     public RecordUnmarshaller createUnmarshaller() throws IllegalArgumentException {
         return new DelimitedRecordParser(this);
     }

--- a/src/org/beanio/stream/delimited/DelimitedWriter.java
+++ b/src/org/beanio/stream/delimited/DelimitedWriter.java
@@ -99,6 +99,7 @@ public class DelimitedWriter implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.line.RecordWriter#write(java.lang.Object)
      */
+    @Override
     public void write(Object value) throws IOException, RecordIOException {
         write((String[]) value);
     }
@@ -141,6 +142,7 @@ public class DelimitedWriter implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.line.RecordWriter#flush()
      */
+    @Override
     public void flush() throws IOException {
         out.flush();
     }
@@ -149,6 +151,7 @@ public class DelimitedWriter implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.line.RecordWriter#close()
      */
+    @Override
     public void close() throws IOException {
         out.close();
     }

--- a/src/org/beanio/stream/fixedlength/FixedLengthReader.java
+++ b/src/org/beanio/stream/fixedlength/FixedLengthReader.java
@@ -106,6 +106,7 @@ public class FixedLengthReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.line.RecordReader#getRecordLineNumber()
      */
+    @Override
     public int getRecordLineNumber() {
         if (recordLineNumber < 0) {
             return recordLineNumber;
@@ -117,6 +118,7 @@ public class FixedLengthReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.line.RecordReader#getRecordText()
      */
+    @Override
     public String getRecordText() {
         return recordText;
     }
@@ -125,6 +127,7 @@ public class FixedLengthReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.line.RecordReader#read()
      */
+    @Override
     public String read() throws IOException, RecordIOException {
         if (eof) {
             recordText = null;
@@ -252,6 +255,7 @@ public class FixedLengthReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.line.RecordReader#close()
      */
+    @Override
     public void close() throws IOException {
         in.close();
     }

--- a/src/org/beanio/stream/fixedlength/FixedLengthRecordParser.java
+++ b/src/org/beanio/stream/fixedlength/FixedLengthRecordParser.java
@@ -35,6 +35,7 @@ public class FixedLengthRecordParser implements RecordMarshaller, RecordUnmarsha
      * (non-Javadoc)
      * @see org.beanio.stream.RecordUnmarshaller#unmarshal(java.lang.String)
      */
+    @Override
     public Object unmarshal(String text) {
         return text;
     }
@@ -43,6 +44,7 @@ public class FixedLengthRecordParser implements RecordMarshaller, RecordUnmarsha
      * (non-Javadoc)
      * @see org.beanio.stream.RecordMarshaller#marshal(java.lang.Object)
      */
+    @Override
     public String marshal(Object record) {
         return marshal((String)record);
     }

--- a/src/org/beanio/stream/fixedlength/FixedLengthRecordParserFactory.java
+++ b/src/org/beanio/stream/fixedlength/FixedLengthRecordParserFactory.java
@@ -39,6 +39,7 @@ public class FixedLengthRecordParserFactory extends FixedLengthParserConfigurati
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#init()
      */
+    @Override
     public void init() throws BeanIOConfigurationException {
         
     }
@@ -47,6 +48,7 @@ public class FixedLengthRecordParserFactory extends FixedLengthParserConfigurati
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createReader(java.io.Reader)
      */
+    @Override
     public RecordReader createReader(Reader in) throws IllegalArgumentException {
         return new FixedLengthReader(in, this);
     }
@@ -55,6 +57,7 @@ public class FixedLengthRecordParserFactory extends FixedLengthParserConfigurati
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createWriter(java.io.Writer)
      */
+    @Override
     public RecordWriter createWriter(Writer out) throws IllegalArgumentException {
         return new FixedLengthWriter(out, getRecordTerminator());
     }
@@ -63,6 +66,7 @@ public class FixedLengthRecordParserFactory extends FixedLengthParserConfigurati
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createMarshaller()
      */
+    @Override
     public RecordMarshaller createMarshaller() throws IllegalArgumentException {
         return parser;
     }
@@ -71,6 +75,7 @@ public class FixedLengthRecordParserFactory extends FixedLengthParserConfigurati
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createUnmarshaller()
      */
+    @Override
     public RecordUnmarshaller createUnmarshaller() throws IllegalArgumentException {
         return parser;
     }

--- a/src/org/beanio/stream/fixedlength/FixedLengthWriter.java
+++ b/src/org/beanio/stream/fixedlength/FixedLengthWriter.java
@@ -57,6 +57,7 @@ public class FixedLengthWriter implements RecordWriter {
 	 * (non-Javadoc)
 	 * @see org.beanio.line.RecordWriter#write(java.lang.Object)
 	 */
+	@Override
 	public void write(Object value) throws IOException, RecordIOException {
 		out.write(value.toString());
 		out.write(recordTerminator);
@@ -66,6 +67,7 @@ public class FixedLengthWriter implements RecordWriter {
 	 * (non-Javadoc)
 	 * @see org.beanio.line.RecordWriter#flush()
 	 */
+	@Override
 	public void flush() throws IOException {
 		out.flush();
 	}
@@ -74,6 +76,7 @@ public class FixedLengthWriter implements RecordWriter {
 	 * (non-Javadoc)
 	 * @see org.beanio.line.RecordWriter#close()
 	 */
+	@Override
 	public void close() throws IOException {
 		out.close();
 	}

--- a/src/org/beanio/stream/json/JsonReader.java
+++ b/src/org/beanio/stream/json/JsonReader.java
@@ -49,6 +49,7 @@ public class JsonReader extends JsonReaderSupport implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#read()
      */
+    @Override
     public Map<String,Object> read() throws IOException, RecordIOException {
         if (eof) {
             return null;
@@ -83,6 +84,7 @@ public class JsonReader extends JsonReaderSupport implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#close()
      */
+    @Override
     public void close() throws IOException {
         if (in != null) {
             try {
@@ -98,6 +100,7 @@ public class JsonReader extends JsonReaderSupport implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#getRecordLineNumber()
      */
+    @Override
     public int getRecordLineNumber() {
         return recordLineNumber;
     }
@@ -106,6 +109,7 @@ public class JsonReader extends JsonReaderSupport implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#getRecordText()
      */
+    @Override
     public String getRecordText() {
         return recordText;
     }

--- a/src/org/beanio/stream/json/JsonReaderSupport.java
+++ b/src/org/beanio/stream/json/JsonReaderSupport.java
@@ -57,7 +57,7 @@ public abstract class JsonReaderSupport {
         String fieldName = null;
         StringBuilder text = null;
         
-        Map<String,Object> map = new HashMap<String,Object>();
+        Map<String,Object> map = new HashMap<>();
         
         int state = 0;
         
@@ -178,7 +178,7 @@ public abstract class JsonReaderSupport {
      * @throws IOException
      */
     protected List<Object> readArray() throws IOException {
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         StringBuilder text = null;
         int state = 0;
         

--- a/src/org/beanio/stream/json/JsonRecordMarshaller.java
+++ b/src/org/beanio/stream/json/JsonRecordMarshaller.java
@@ -51,6 +51,7 @@ public class JsonRecordMarshaller extends JsonWriterSupport implements RecordMar
      * @see org.beanio.stream.RecordMarshaller#marshal(java.lang.Object)
      */
     @SuppressWarnings("unchecked")
+    @Override
     public String marshal(Object record) {
         return marshal((Map<String,Object>) record);
     }

--- a/src/org/beanio/stream/json/JsonRecordParserFactory.java
+++ b/src/org/beanio/stream/json/JsonRecordParserFactory.java
@@ -41,12 +41,14 @@ public class JsonRecordParserFactory extends JsonParserConfiguration implements 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#init()
      */
+    @Override
     public void init() throws IllegalArgumentException { }
 
     /*
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createReader(java.io.Reader)
      */
+    @Override
     public RecordReader createReader(Reader in) throws IllegalArgumentException {
         return new JsonReader(in);
     }
@@ -55,6 +57,7 @@ public class JsonRecordParserFactory extends JsonParserConfiguration implements 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createWriter(java.io.Writer)
      */
+    @Override
     public RecordWriter createWriter(Writer out) throws IllegalArgumentException {
         return new JsonWriter(out, this);
     }
@@ -63,6 +66,7 @@ public class JsonRecordParserFactory extends JsonParserConfiguration implements 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createMarshaller()
      */
+    @Override
     public RecordMarshaller createMarshaller() throws IllegalArgumentException {
         return new JsonRecordMarshaller(this);
     }
@@ -71,6 +75,7 @@ public class JsonRecordParserFactory extends JsonParserConfiguration implements 
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createUnmarshaller()
      */
+    @Override
     public RecordUnmarshaller createUnmarshaller() throws IllegalArgumentException {
         return new JsonRecordUnmarshaller();
     }

--- a/src/org/beanio/stream/json/JsonRecordUnmarshaller.java
+++ b/src/org/beanio/stream/json/JsonRecordUnmarshaller.java
@@ -42,6 +42,7 @@ public class JsonRecordUnmarshaller extends JsonReaderSupport implements RecordU
      * (non-Javadoc)
      * @see org.beanio.stream.RecordUnmarshaller#unmarshal(java.lang.String)
      */
+    @Override
     public Map<String,Object> unmarshal(String text) throws RecordIOException {
         if (text == null) {
             return null;

--- a/src/org/beanio/stream/json/JsonWriter.java
+++ b/src/org/beanio/stream/json/JsonWriter.java
@@ -54,6 +54,7 @@ public class JsonWriter extends JsonWriterSupport implements RecordWriter {
      * @see org.beanio.stream.RecordWriter#write(java.lang.Object)
      */
     @SuppressWarnings("unchecked")
+    @Override
     public void write(Object record) throws IOException {
         write((Map<String,Object>)record);
         out.write(getLineSeparator());
@@ -63,6 +64,7 @@ public class JsonWriter extends JsonWriterSupport implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#flush()
      */
+    @Override
     public void flush() throws IOException {
         out.flush();
     }
@@ -71,6 +73,7 @@ public class JsonWriter extends JsonWriterSupport implements RecordWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#close()
      */
+    @Override
     public void close() throws IOException {
         out.close();
     }

--- a/src/org/beanio/stream/xml/ElementStack.java
+++ b/src/org/beanio/stream/xml/ElementStack.java
@@ -146,7 +146,7 @@ class ElementStack {
      */
     public void addNamespace(String prefix, String namespace) {
         if (nsMap == null) {
-            nsMap = new HashMap<String,String>();
+            nsMap = new HashMap<>();
         }
         nsMap.put(namespace, prefix);
     }

--- a/src/org/beanio/stream/xml/XmlParserConfiguration.java
+++ b/src/org/beanio/stream/xml/XmlParserConfiguration.java
@@ -35,7 +35,7 @@ public class XmlParserConfiguration implements Cloneable {
     private String encoding = "utf-8";
     
     /* Map of namespace prefixes to namespace uri's */
-    private Map<String,String> namespaceMap = new HashMap<String,String>();
+    private Map<String,String> namespaceMap = new HashMap<>();
     
     /**
      * Constructs a new <tt>XmlConfiguration</tt>.

--- a/src/org/beanio/stream/xml/XmlReader.java
+++ b/src/org/beanio/stream/xml/XmlReader.java
@@ -132,6 +132,7 @@ public class XmlReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#read()
      */
+    @Override
     public Document read() throws IOException, RecordIOException {
         if (eof) {
             return null;
@@ -302,6 +303,7 @@ public class XmlReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#close()
      */
+    @Override
     public void close() throws IOException {
         try {
             in.close();
@@ -317,6 +319,7 @@ public class XmlReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#getRecordLineNumber()
      */
+    @Override
     public int getRecordLineNumber() {
         return recordLineNumber;
     }
@@ -325,6 +328,7 @@ public class XmlReader implements RecordReader {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReader#getRecordText()
      */
+    @Override
     public String getRecordText() {
         return null;
     }

--- a/src/org/beanio/stream/xml/XmlRecordMarshaller.java
+++ b/src/org/beanio/stream/xml/XmlRecordMarshaller.java
@@ -51,7 +51,7 @@ public class XmlRecordMarshaller implements RecordMarshaller {
     /* the next index to try when auto generating a namespace prefix */
     private int namespaceCount = 0;
     /* Map of auto-generated namespace prefixes to namespaces */
-    private Map<String,String> namespaceMap = new HashMap<String,String>();
+    private Map<String,String> namespaceMap = new HashMap<>();
 
     /**
      * Constructs a new <tt>XmlRecordMarshaller</tt>.
@@ -295,7 +295,7 @@ public class XmlRecordMarshaller implements RecordMarshaller {
                 if (declareNamespace) {
                     out.writeNamespace(attPrefix, attNamespace);
                     if (attPrefixSet == null) {
-                        attPrefixSet = new HashSet<String>();
+                        attPrefixSet = new HashSet<>();
                     }
                     attPrefixSet.add(attPrefix);
                 }

--- a/src/org/beanio/stream/xml/XmlRecordMarshaller.java
+++ b/src/org/beanio/stream/xml/XmlRecordMarshaller.java
@@ -99,6 +99,7 @@ public class XmlRecordMarshaller implements RecordMarshaller {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordMarshaller#marshal(java.lang.Object)
      */
+    @Override
     public String marshal(Object record) throws RecordIOException {
         try {
             return marshal((Document)record);

--- a/src/org/beanio/stream/xml/XmlRecordParserFactory.java
+++ b/src/org/beanio/stream/xml/XmlRecordParserFactory.java
@@ -40,6 +40,7 @@ public class XmlRecordParserFactory extends XmlParserConfiguration
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#init()
      */
+    @Override
     public void init() throws IllegalArgumentException {
         
     }
@@ -48,6 +49,7 @@ public class XmlRecordParserFactory extends XmlParserConfiguration
      * (non-Javadoc)
      * @see org.beanio.stream.RecordReaderFactory#createReader(java.io.Reader)
      */
+    @Override
     public RecordReader createReader(Reader in) throws IllegalArgumentException {
         Document base = null;
         if (source != null) {
@@ -61,6 +63,7 @@ public class XmlRecordParserFactory extends XmlParserConfiguration
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriterFactory#createWriter(java.io.Writer)
      */
+    @Override
     public RecordWriter createWriter(Writer out) throws IllegalArgumentException {
         return new XmlWriter(out, this);
     }
@@ -69,6 +72,7 @@ public class XmlRecordParserFactory extends XmlParserConfiguration
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createMarshaller()
      */
+    @Override
     public RecordMarshaller createMarshaller() throws IllegalArgumentException {
         return new XmlRecordMarshaller(this);
     }
@@ -77,6 +81,7 @@ public class XmlRecordParserFactory extends XmlParserConfiguration
      * (non-Javadoc)
      * @see org.beanio.stream.RecordParserFactory#createUnmarshaller()
      */
+    @Override
     public RecordUnmarshaller createUnmarshaller() throws IllegalArgumentException {
         return new XmlRecordUnmarshaller();
     }
@@ -85,6 +90,7 @@ public class XmlRecordParserFactory extends XmlParserConfiguration
      * (non-Javadoc)
      * @see org.beanio.stream.xml.XmlDocumentAware#setSource(org.beanio.stream.xml.XmlDocumentSource)
      */
+    @Override
     public void setConfiguration(XmlStreamConfiguration source) {
         this.source = source;
     }

--- a/src/org/beanio/stream/xml/XmlRecordUnmarshaller.java
+++ b/src/org/beanio/stream/xml/XmlRecordUnmarshaller.java
@@ -55,6 +55,7 @@ public class XmlRecordUnmarshaller implements RecordUnmarshaller {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordUnmarshaller#unmarshal(java.lang.String)
      */
+    @Override
     public Object unmarshal(String text) throws RecordIOException {
         try {
             return documentBuilder.parse(new InputSource(new StringReader(text)));

--- a/src/org/beanio/stream/xml/XmlWriter.java
+++ b/src/org/beanio/stream/xml/XmlWriter.java
@@ -95,7 +95,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
     /* the next index to try when auto generating a namespace prefix */
     private int namespaceCount = 0;
     /* Map of auto-generated namespace prefixes to namespaces */
-    private Map<String,String> namespaceMap = new HashMap<String,String>();
+    private Map<String,String> namespaceMap = new HashMap<>();
     
     /* the minimum level last stored when the state was updated */
     private int dirtyLevel = 0;
@@ -365,7 +365,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
                 if (declareNamespace) {
                     out.writeNamespace(attPrefix, attNamespace);
                     if (attPrefixSet == null) {
-                        attPrefixSet = new HashSet<String>();
+                        attPrefixSet = new HashSet<>();
                     }
                     attPrefixSet.add(attPrefix);
                 }
@@ -664,7 +664,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
         if (s.length % 2 != 0) {
             throw new IllegalStateException("Invalid state information for key '" + key + "'");
         }
-        Map<String,String> map = new HashMap<String,String>();
+        Map<String,String> map = new HashMap<>();
         for (int n=0; n<s.length; n+=2) {
             map.put(s[n], s[n+1]);
         }

--- a/src/org/beanio/stream/xml/XmlWriter.java
+++ b/src/org/beanio/stream/xml/XmlWriter.java
@@ -182,6 +182,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#write(java.lang.Object)
      */
+    @Override
     public void write(Object record) throws IOException {
         try {
             // write the XMl header if needed
@@ -430,6 +431,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#flush()
      */
+    @Override
     public void flush() throws IOException {
         try {
             out.flush();
@@ -443,6 +445,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.stream.RecordWriter#close()
      */
+    @Override
     public void close() throws IOException {
         try {
             while (elementStack != null) {
@@ -524,6 +527,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.util.StatefulWriter#updateState(java.lang.String, java.util.Map)
      */
+    @Override
     public void updateState(String namespace, Map<String, Object> state) {
         state.put(getKey(namespace, OUTPUT_HEADER_KEY), outputHeader);
         state.put(getKey(namespace, NAMESPACE_MAP_KEY), toToken(namespaceMap));
@@ -567,6 +571,7 @@ public class XmlWriter implements RecordWriter, StatefulWriter {
      * (non-Javadoc)
      * @see org.beanio.util.StatefulWriter#restoreState(java.lang.String, java.util.Map)
      */
+    @Override
     public void restoreState(String namespace, Map<String, Object> state) throws IllegalStateException {
         this.outputHeader = (Boolean) getRequired(namespace, OUTPUT_HEADER_KEY, state);
         

--- a/src/org/beanio/types/BigDecimalTypeHandler.java
+++ b/src/org/beanio/types/BigDecimalTypeHandler.java
@@ -43,6 +43,7 @@ public class BigDecimalTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return BigDecimal.class;
     }

--- a/src/org/beanio/types/BigIntegerTypeHandler.java
+++ b/src/org/beanio/types/BigIntegerTypeHandler.java
@@ -43,6 +43,7 @@ public class BigIntegerTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return BigInteger.class;
     }

--- a/src/org/beanio/types/BooleanTypeHandler.java
+++ b/src/org/beanio/types/BooleanTypeHandler.java
@@ -29,6 +29,7 @@ public class BooleanTypeHandler implements TypeHandler {
      * @param text the text to parse
      * @return new Boolean
      */
+    @Override
     public Boolean parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text))
             return null;
@@ -40,6 +41,7 @@ public class BooleanTypeHandler implements TypeHandler {
      * Returns {@link Boolean#toString()}, or <tt>null</tt> if <tt>value</tt>
      * is <tt>null</tt>.
      */
+    @Override
     public String format(Object value) {
         if (value == null)
             return null;
@@ -50,6 +52,7 @@ public class BooleanTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Boolean.class;
     }

--- a/src/org/beanio/types/ByteTypeHandler.java
+++ b/src/org/beanio/types/ByteTypeHandler.java
@@ -43,6 +43,7 @@ public class ByteTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Byte.class;
     }

--- a/src/org/beanio/types/CalendarTypeHandler.java
+++ b/src/org/beanio/types/CalendarTypeHandler.java
@@ -50,6 +50,7 @@ public class CalendarTypeHandler extends DateTypeHandlerSupport {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#parse(java.lang.String)
      */
+    @Override
     public Calendar parse(String text) throws TypeConversionException {
         Date date = parseDate(text);
         if (date == null) {
@@ -64,6 +65,7 @@ public class CalendarTypeHandler extends DateTypeHandlerSupport {
      * (non-Javadoc)
      * @see org.beanio.types.AbstractDateTypeHandler#format(java.lang.Object)
      */
+    @Override
     public String format(Object value) {
         return formatCalendar((Calendar)value);
     }
@@ -76,6 +78,7 @@ public class CalendarTypeHandler extends DateTypeHandlerSupport {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Calendar.class;
     }

--- a/src/org/beanio/types/CharacterTypeHandler.java
+++ b/src/org/beanio/types/CharacterTypeHandler.java
@@ -28,6 +28,7 @@ public class CharacterTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#parse(java.lang.String)
      */
+    @Override
     public Character parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text))
             return null;
@@ -43,6 +44,7 @@ public class CharacterTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#format(java.lang.Object)
      */
+    @Override
     public String format(Object value) {
         if (value == null)
             return null;
@@ -53,6 +55,7 @@ public class CharacterTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Character.class;
     }

--- a/src/org/beanio/types/DateTypeHandler.java
+++ b/src/org/beanio/types/DateTypeHandler.java
@@ -48,6 +48,7 @@ public class DateTypeHandler extends DateTypeHandlerSupport {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#parse(java.lang.String)
      */
+    @Override
     public Date parse(String text) throws TypeConversionException {
         return super.parseDate(text);
     }
@@ -56,6 +57,7 @@ public class DateTypeHandler extends DateTypeHandlerSupport {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#format(java.lang.Object)
      */
+    @Override
     public String format(Object value) {
         return super.formatDate((Date)value);
     }
@@ -64,6 +66,7 @@ public class DateTypeHandler extends DateTypeHandlerSupport {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Date.class;
     }

--- a/src/org/beanio/types/DateTypeHandlerSupport.java
+++ b/src/org/beanio/types/DateTypeHandlerSupport.java
@@ -114,6 +114,7 @@ public abstract class DateTypeHandlerSupport extends LocaleSupport implements Co
      * (non-Javadoc)
      * @see org.beanio.types.AbstractDateTypeHandler#newInstance(java.util.Properties)
      */
+    @Override
     public DateTypeHandlerSupport newInstance(Properties properties) throws IllegalArgumentException {
         String pattern = properties.getProperty(FORMAT_SETTING);
         if (pattern == null || "".equals(pattern)) {

--- a/src/org/beanio/types/DoubleTypeHandler.java
+++ b/src/org/beanio/types/DoubleTypeHandler.java
@@ -43,6 +43,7 @@ public class DoubleTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Double.class;
     }

--- a/src/org/beanio/types/FloatTypeHandler.java
+++ b/src/org/beanio/types/FloatTypeHandler.java
@@ -41,6 +41,7 @@ public class FloatTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Float.class;
     }

--- a/src/org/beanio/types/IntegerTypeHandler.java
+++ b/src/org/beanio/types/IntegerTypeHandler.java
@@ -43,6 +43,7 @@ public class IntegerTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Integer.class;
     }

--- a/src/org/beanio/types/LongTypeHandler.java
+++ b/src/org/beanio/types/LongTypeHandler.java
@@ -43,6 +43,7 @@ public class LongTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Long.class;
     }

--- a/src/org/beanio/types/NumberTypeHandler.java
+++ b/src/org/beanio/types/NumberTypeHandler.java
@@ -45,6 +45,7 @@ public abstract class NumberTypeHandler extends LocaleSupport implements Configu
      *    or an empty string
      * @throws TypeConversionException if the text is not a valid number
      */
+    @Override
     public final Number parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text)) {
             return null;
@@ -113,6 +114,7 @@ public abstract class NumberTypeHandler extends LocaleSupport implements Configu
      * (non-Javadoc)
      * @see org.beanio.types.ConfigurableTypeHandler#newInstance(java.util.Properties)
      */
+    @Override
     public TypeHandler newInstance(Properties properties) throws IllegalArgumentException {
         String pattern = properties.getProperty(FORMAT_SETTING);
         if (pattern == null || "".equals(pattern)) {
@@ -145,6 +147,7 @@ public abstract class NumberTypeHandler extends LocaleSupport implements Configu
      * @param value the number to format
      * @return the formatted number
      */
+    @Override
     public String format(Object value) {
         if (value == null)
             return null;

--- a/src/org/beanio/types/ShortTypeHandler.java
+++ b/src/org/beanio/types/ShortTypeHandler.java
@@ -43,6 +43,7 @@ public class ShortTypeHandler extends NumberTypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Short.class;
     }

--- a/src/org/beanio/types/StringTypeHandler.java
+++ b/src/org/beanio/types/StringTypeHandler.java
@@ -31,6 +31,7 @@ public class StringTypeHandler implements TypeHandler {
      * @param text the text to parse
      * @return the parsed <tt>String</tt>
      */
+    @Override
     public String parse(String text) {
         if (text != null) {
             if (trim) {
@@ -48,6 +49,7 @@ public class StringTypeHandler implements TypeHandler {
      * @param value the value to format
      * @return the formatted value, or <tt>null</tt> if <tt>value</tt> is <tt>null</tt>
      */
+    @Override
     public String format(Object value) {
         if (value == null)
             return null;
@@ -58,6 +60,7 @@ public class StringTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return String.class;
     }

--- a/src/org/beanio/types/URLTypeHandler.java
+++ b/src/org/beanio/types/URLTypeHandler.java
@@ -31,6 +31,7 @@ public class URLTypeHandler implements TypeHandler {
      * @return the parsed {@link URL} or null if <tt>text</tt>
      *   is null or an empty string
      */
+    @Override
     public Object parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text)) {
             return null;
@@ -51,6 +52,7 @@ public class URLTypeHandler implements TypeHandler {
      * @param value the {@link URL} to format
      * @return the formatted text
      */
+    @Override
     public String format(Object value) {
         if (value == null)
             return null;
@@ -61,6 +63,7 @@ public class URLTypeHandler implements TypeHandler {
     /**
      * Returns {@link URL}.
      */
+    @Override
     public Class<?> getType() {
         return URL.class;
     }

--- a/src/org/beanio/types/UUIDTypeHandler.java
+++ b/src/org/beanio/types/UUIDTypeHandler.java
@@ -31,6 +31,7 @@ public class UUIDTypeHandler implements TypeHandler {
      * @return the parsed {@link UUID} or null if <tt>text</tt>
      *   is null or an empty string
      */
+    @Override
     public Object parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text)) {
             return null;
@@ -51,6 +52,7 @@ public class UUIDTypeHandler implements TypeHandler {
      * @param value the {@link UUID} to format
      * @return the formatted text
      */
+    @Override
     public String format(Object value) {
         if (value == null)
             return null;
@@ -61,6 +63,7 @@ public class UUIDTypeHandler implements TypeHandler {
     /**
      * Returns {@link UUID}.
      */
+    @Override
     public Class<?> getType() {
         return UUID.class;
     }

--- a/src/org/beanio/types/xml/XmlBooleanTypeHandler.java
+++ b/src/org/beanio/types/xml/XmlBooleanTypeHandler.java
@@ -39,6 +39,7 @@ public class XmlBooleanTypeHandler implements TypeHandler {
      * @param text the text to parse
      * @return new Boolean
      */
+    @Override
     public Boolean parse(String text) throws TypeConversionException {
         if (text == null || "".equals(text))
             return null;
@@ -58,6 +59,7 @@ public class XmlBooleanTypeHandler implements TypeHandler {
      * Returns {@link Boolean#toString()}, or <tt>null</tt> if <tt>value</tt>
      * is <tt>null</tt>.
      */
+    @Override
     public String format(Object value) {
         if (value == null)
             return null;
@@ -75,6 +77,7 @@ public class XmlBooleanTypeHandler implements TypeHandler {
      * (non-Javadoc)
      * @see org.beanio.types.TypeHandler#getType()
      */
+    @Override
     public Class<?> getType() {
         return Boolean.class;
     }

--- a/test/org/beanio/beans/Order.java
+++ b/test/org/beanio/beans/Order.java
@@ -69,6 +69,7 @@ public class Order {
     public void setItemMap(Map<String, OrderItem> itemMap) {
         this.itemMap = itemMap;
     }
+    @Override
     public String toString() {
         return id;
     }

--- a/test/org/beanio/beans/OrderBatch.java
+++ b/test/org/beanio/beans/OrderBatch.java
@@ -38,6 +38,7 @@ public class OrderBatch {
         orders = Arrays.asList(orderArray);
     }
     
+    @Override
     public String toString() {
         return "OrderBatch" +
             "[count=" + batchCount +

--- a/test/org/beanio/beans/Person.java
+++ b/test/org/beanio/beans/Person.java
@@ -42,6 +42,7 @@ public class Person {
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }
+    @Override
     public String toString() {
         return firstName + " " + lastName;
     }

--- a/test/org/beanio/parser/annotation/AnnotatedUser.java
+++ b/test/org/beanio/parser/annotation/AnnotatedUser.java
@@ -32,6 +32,7 @@ public class AnnotatedUser extends AnnotatedUserSupport implements AnnotatedUser
     @Field(at=-1)
     public String end;
     
+    @Override
     public String[] getHands() {
         return hands;
     }

--- a/test/org/beanio/parser/annotation/AnnotationTest.java
+++ b/test/org/beanio/parser/annotation/AnnotationTest.java
@@ -113,13 +113,13 @@ public class AnnotationTest extends ParserTest {
             Assert.assertEquals("left", user.getHands()[0]);
             Assert.assertEquals("right", user.getHands()[1]);
             Assert.assertEquals(new GregorianCalendar(1970, 0, 1).getTime(), user.birthDate);
-            Assert.assertEquals(new Integer(28), user.getAge());
+            Assert.assertEquals(Integer.valueOf(28), user.getAge());
             Assert.assertEquals(2, user.letters.size());
-            Assert.assertEquals(new Character('A'), user.letters.get(0));
-            Assert.assertEquals(new Character('B'), user.letters.get(1));
+            Assert.assertEquals(Character.valueOf('A'), user.letters.get(0));
+            Assert.assertEquals(Character.valueOf('B'), user.letters.get(1));
             Assert.assertEquals(1, user.numbers.size());
             Assert.assertEquals(LinkedList.class, user.numbers.getClass());
-            Assert.assertEquals(new Integer(1), user.numbers.get(0));
+            Assert.assertEquals(Integer.valueOf(1), user.numbers.get(0));
             Assert.assertEquals("END", user.end);
             
             Assert.assertEquals(input[i], m[i].marshal(user).toString());

--- a/test/org/beanio/parser/bean/BeanParserTest.java
+++ b/test/org/beanio/parser/bean/BeanParserTest.java
@@ -243,7 +243,7 @@ public class BeanParserTest extends ParserTest {
         w.setId(1);
         w.setName("name1");
         
-        Map<String,Widget> map = new HashMap<String,Widget>();
+        Map<String,Widget> map = new HashMap<>();
         map.put("widget", w);
         
         StringWriter text = new StringWriter();

--- a/test/org/beanio/parser/bean/BeanParserTest.java
+++ b/test/org/beanio/parser/bean/BeanParserTest.java
@@ -286,7 +286,7 @@ public class BeanParserTest extends ParserTest {
     
     @Test
     @SuppressWarnings("rawtypes")
-    public void testNestedBeans() throws IOException {
+    public void testNestedBeans() {
         BeanReader in = factory.createReader("w10", new InputStreamReader(
             getClass().getResourceAsStream("w10_nestedBeans.txt")));
         

--- a/test/org/beanio/parser/bean/Widget.java
+++ b/test/org/beanio/parser/bean/Widget.java
@@ -75,7 +75,7 @@ public class Widget {
     }
     public void addPart(Widget w) {
         if (partsList == null) {
-            partsList = new ArrayList<Widget>();
+            partsList = new ArrayList<>();
         }
         partsList.add(w);
     }

--- a/test/org/beanio/parser/bean/Widget.java
+++ b/test/org/beanio/parser/bean/Widget.java
@@ -28,6 +28,7 @@ public class Widget {
     private List<Widget> partsList;
     private Map<String,Widget> partsMap;
     
+    @Override
     public String toString() {
         return 
             "[id=" + id +

--- a/test/org/beanio/parser/collection/CollectionFieldParserTest.java
+++ b/test/org/beanio/parser/collection/CollectionFieldParserTest.java
@@ -94,7 +94,7 @@ public class CollectionFieldParserTest extends ParserTest {
         try {
             CollectionBean bean = (CollectionBean) in.read();
             assertArrayEquals(new int[] { 1, 100, 24 }, bean.getArray());
-            assertEquals(new HashSet<Character>(Arrays.asList('A', 'B', 'C', ' ')), bean.getSet());
+            assertEquals(new HashSet<>(Arrays.asList('A', 'B', 'C', ' ')), bean.getSet());
 
             StringWriter text = new StringWriter();
             factory.createWriter("fc1", text).write(bean);

--- a/test/org/beanio/parser/json/segment/JsonSegmentParserTest.java
+++ b/test/org/beanio/parser/json/segment/JsonSegmentParserTest.java
@@ -56,7 +56,7 @@ public class JsonSegmentParserTest extends ParserTest {
         
         try {
             Map map = (Map) in.read();
-            assertEquals(new Integer(2), map.get("count"));
+            assertEquals(Integer.valueOf(2), map.get("count"));
             
             List list = (List) map.get("friends");
             Person person = (Person) list.get(0);

--- a/test/org/beanio/parser/lazy/LazyTest.java
+++ b/test/org/beanio/parser/lazy/LazyTest.java
@@ -34,7 +34,7 @@ public class LazyTest extends ParserTest {
         user = (LazyUser) u.unmarshal("kevin1         ");
         assertEquals("kevin", user.name);
         assertNotNull(user.account);
-        assertEquals(new Integer(1), user.account.getNumber());
+        assertEquals(Integer.valueOf(1), user.account.getNumber());
         assertEquals("", user.account.getText());
     }
     

--- a/test/org/beanio/parser/multiline/MultilineRecordTest.java
+++ b/test/org/beanio/parser/multiline/MultilineRecordTest.java
@@ -124,7 +124,7 @@ public class MultilineRecordTest extends ParserTest {
     }
         
     @Test
-    public void testNestedRecorGroup() throws ParseException {
+    public void testNestedRecorGroup() {
         BeanReader in = factory.createReader("ml2", new InputStreamReader(
             getClass().getResourceAsStream("ml2.txt")));
         
@@ -165,7 +165,7 @@ public class MultilineRecordTest extends ParserTest {
     
     @Test
     @SuppressWarnings("rawtypes")
-    public void testNestedRecorGroupCollections() throws ParseException {
+    public void testNestedRecorGroupCollections() {
         BeanReader in = factory.createReader("ml3", new InputStreamReader(
             getClass().getResourceAsStream("ml3.txt")));
         
@@ -206,7 +206,7 @@ public class MultilineRecordTest extends ParserTest {
     }
     
     @Test
-    public void testRecordMap() throws ParseException {
+    public void testRecordMap() {
         BeanReader in = factory.createReader("ml4", new InputStreamReader(
             getClass().getResourceAsStream("ml4.txt")));
         
@@ -257,7 +257,7 @@ public class MultilineRecordTest extends ParserTest {
     }
     
     @Test
-    public void testNestedRecorGroupNonCollection() throws ParseException {
+    public void testNestedRecorGroupNonCollection() {
         BeanReader in = factory.createReader("ml5", new InputStreamReader(
             getClass().getResourceAsStream("ml5.txt")));
         
@@ -286,7 +286,7 @@ public class MultilineRecordTest extends ParserTest {
     }
     
     @Test
-    public void testEmptyRecordList() throws ParseException {
+    public void testEmptyRecordList() {
         BeanReader in = factory.createReader("ml6", new InputStreamReader(
             getClass().getResourceAsStream("ml6.txt")));
         
@@ -306,7 +306,7 @@ public class MultilineRecordTest extends ParserTest {
     }
     
     @Test
-    public void testInlineRecordMap() throws ParseException {
+    public void testInlineRecordMap() {
         BeanReader in = factory.createReader("ml7", new InputStreamReader(
             getClass().getResourceAsStream("ml7.txt")));
         

--- a/test/org/beanio/parser/property/PropertyParserTest.java
+++ b/test/org/beanio/parser/property/PropertyParserTest.java
@@ -46,7 +46,7 @@ public class PropertyParserTest extends ParserTest {
         
         try {
             Map map = (Map) in.read();
-            assertEquals(new Integer(1), map.get("id"));
+            assertEquals(Integer.valueOf(1), map.get("id"));
             assertNull(map.get("recordType"));
             
             StringWriter text = new StringWriter();
@@ -61,8 +61,8 @@ public class PropertyParserTest extends ParserTest {
             assertEquals("Detail,John" + lineSeparator, text.toString());
             
             map = (Map) in.read();
-            assertEquals(new Integer(3), map.get("id"));
-            assertEquals(new Integer(1), map.get("recordCount"));
+            assertEquals(Integer.valueOf(3), map.get("id"));
+            assertEquals(Integer.valueOf(1), map.get("recordCount"));
             assertNull(map.get("recordType"));
             
             text = new StringWriter();

--- a/test/org/beanio/parser/substitution/PropertySubstitutionParserTest.java
+++ b/test/org/beanio/parser/substitution/PropertySubstitutionParserTest.java
@@ -60,7 +60,7 @@ public class PropertySubstitutionParserTest extends ParserTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testDefaultSubstitution() throws ParseException {
+    public void testDefaultSubstitution() {
         Properties properties = new Properties();
         properties.setProperty("dateFormat", "yyyy-MM-dd");
         
@@ -73,7 +73,7 @@ public class PropertySubstitutionParserTest extends ParserTest {
     }
 
     @Test(expected=BeanIOConfigurationException.class)
-    public void testMissingProperty() throws ParseException {
+    public void testMissingProperty() {
         factory.loadResource("org/beanio/parser/substitution/substitution_mapping.xml");
     }    
 }

--- a/test/org/beanio/parser/target/TargetTest.java
+++ b/test/org/beanio/parser/target/TargetTest.java
@@ -53,7 +53,7 @@ public class TargetTest extends ParserTest {
         assertEquals("N,,kev,kevo", marshaller.marshal(list).toString());
         
         Integer age = (Integer) unmarshaller.unmarshal("A,jen,28");
-        assertEquals(new Integer(28), age);
+        assertEquals(Integer.valueOf(28), age);
         assertEquals("A,unknown,28", marshaller.marshal(age).toString());
     }
     

--- a/test/org/beanio/parser/template/TemplateParserTest.java
+++ b/test/org/beanio/parser/template/TemplateParserTest.java
@@ -47,7 +47,7 @@ public class TemplateParserTest extends ParserTest {
         
         try {
             Map map = (Map) in.read();
-            assertEquals(new Integer(1), map.get("id"));
+            assertEquals(Integer.valueOf(1), map.get("id"));
             assertEquals("joe", map.get("name"));
             assertEquals('M', map.get("gender"));
         }
@@ -67,7 +67,7 @@ public class TemplateParserTest extends ParserTest {
             assertEquals('M', map.get("gender"));
             assertNotNull(map.get("bean"));
             map = (Map) map.get("bean");
-            assertEquals(new Integer(1), map.get("id"));
+            assertEquals(Integer.valueOf(1), map.get("id"));
             assertEquals("joe", map.get("name"));
             
         }
@@ -84,7 +84,7 @@ public class TemplateParserTest extends ParserTest {
         
         try {
             Map map = (Map) in.read();
-            assertEquals(new Integer(1), map.get("id"));
+            assertEquals(Integer.valueOf(1), map.get("id"));
             assertEquals("joe", map.get("firstName"));
             assertEquals("smith", map.get("lastName"));
             assertEquals('M', map.get("gender"));

--- a/test/org/beanio/parser/trim/TrimTest.java
+++ b/test/org/beanio/parser/trim/TrimTest.java
@@ -31,6 +31,6 @@ public class TrimTest extends ParserTest {
         Map map = (Map) u.unmarshal("\"jen  \",jen  ,1    ");
         assertEquals("jen  ", map.get("text"));
         assertEquals("jen", map.get("text_trim"));
-        assertEquals(new Integer(1), map.get("number"));
+        assertEquals(Integer.valueOf(1), map.get("number"));
     }
 }

--- a/test/org/beanio/parser/types/TypeEnum.java
+++ b/test/org/beanio/parser/types/TypeEnum.java
@@ -4,6 +4,7 @@ public enum TypeEnum {
     ONE,
     TWO;
     
+    @Override
     public String toString() {
         return super.toString().toLowerCase();
     } 

--- a/test/org/beanio/parser/types/TypesParserTest.java
+++ b/test/org/beanio/parser/types/TypesParserTest.java
@@ -58,13 +58,13 @@ public class TypesParserTest extends ParserTest {
         try {
             ObjectRecord record;
             record = (ObjectRecord) in.read();
-            assertEquals(new Byte((byte) 10), record.getByteValue());
-            assertEquals(new Short((short) 10), record.getShortValue());
-            assertEquals(new Integer(-10), record.getIntegerValue());
-            assertEquals(new Long(10), record.getLongValue());
-            assertEquals(new Float(10.1f), record.getFloatValue());
-            assertEquals(new Double(-10.1), record.getDoubleValue());
-            assertEquals(new Character('A'), record.getCharacterValue());
+            assertEquals(Byte.valueOf((byte) 10), record.getByteValue());
+            assertEquals(Short.valueOf((short) 10), record.getShortValue());
+            assertEquals(Integer.valueOf(-10), record.getIntegerValue());
+            assertEquals(Long.valueOf(10), record.getLongValue());
+            assertEquals(Float.valueOf(10.1f), record.getFloatValue());
+            assertEquals(Double.valueOf(-10.1), record.getDoubleValue());
+            assertEquals(Character.valueOf('A'), record.getCharacterValue());
             assertEquals("ABC", record.getStringValue());
             assertEquals(new SimpleDateFormat("MMddyy").parse("010170"), record.getDateValue());
             assertEquals(Boolean.TRUE, record.getBooleanValue());
@@ -240,12 +240,12 @@ public class TypesParserTest extends ParserTest {
         try {
             ObjectRecord record;
             record = (ObjectRecord) in.read();
-            assertEquals(new Byte((byte)1), record.getByteValue());
-            assertEquals(new Short((short)2), record.getShortValue());
-            assertEquals(new Integer(-3), record.getIntegerValue());
-            assertEquals(new Long(4), record.getLongValue());
-            assertEquals(new Float("5.1"), record.getFloatValue());
-            assertEquals(new Double("-6.1"), record.getDoubleValue());
+            assertEquals(Byte.valueOf((byte)1), record.getByteValue());
+            assertEquals(Short.valueOf((short)2), record.getShortValue());
+            assertEquals(Integer.valueOf(-3), record.getIntegerValue());
+            assertEquals(Long.valueOf(4), record.getLongValue());
+            assertEquals(Float.valueOf("5.1"), record.getFloatValue());
+            assertEquals(Double.valueOf("-6.1"), record.getDoubleValue());
             assertEquals(sdf.parse("2011-01-01"), record.getDateValue());
             assertEquals(new BigInteger("10"), record.getBigIntegerValue());
             assertEquals(new BigDecimal("10.5"), record.getBigDecimalValue());

--- a/test/org/beanio/parser/writemode/WriteModeParserTest.java
+++ b/test/org/beanio/parser/writemode/WriteModeParserTest.java
@@ -45,15 +45,19 @@ public class WriteModeParserTest extends ParserTest {
     @Test
     public void testBasic() {
         PersonInterface person = new PersonInterface() {
+            @Override
             public String getFirstName() {
                 return "John";
             }
+            @Override
             public String getLastName() {
                 return "Smith";
             }
+            @Override
             public int getAge() {
                 return 21;
             }
+            @Override
             public Date getBirthDate() {
                 try {
                     return new SimpleDateFormat("yyyy-MM-dd").parse("2011-01-01");

--- a/test/org/beanio/parser/xml/Address.java
+++ b/test/org/beanio/parser/xml/Address.java
@@ -45,6 +45,7 @@ public class Address {
         this.zip = zip;
     }
     
+    @Override
     public String toString() {
         return "[" + city + ", " + state + " " + zip + "]";
     }

--- a/test/org/beanio/parser/xml/Person.java
+++ b/test/org/beanio/parser/xml/Person.java
@@ -89,6 +89,7 @@ public class Person {
         this.age = age;
     }
     
+    @Override
     public String toString() {
         return gender + ": " + firstName + " " + lastName + ":" + color + " " + addressList;
     }

--- a/test/org/beanio/parser/xml/Person.java
+++ b/test/org/beanio/parser/xml/Person.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class Person {
     /* used to test that the setter is not called for missing elements */
     public static final String DEFAULT_NAME = new String();
-    public static final Integer DEFAULT_AGE = new Integer(-1);
+    public static final Integer DEFAULT_AGE = Integer.valueOf(-1);
     
     private String type;
     private String gender;

--- a/test/org/beanio/parser/xml/field/XmlFieldTest.java
+++ b/test/org/beanio/parser/xml/field/XmlFieldTest.java
@@ -49,7 +49,7 @@ public class XmlFieldTest extends XmlParserTest {
         BeanWriter out = factory.createWriter("stream", s);
         try {
             Person person = (Person) in.read();
-            assertEquals(new Integer(25), person.getAge());
+            assertEquals(Integer.valueOf(25), person.getAge());
             out.write(person);
             
             person = (Person) in.read();
@@ -76,7 +76,7 @@ public class XmlFieldTest extends XmlParserTest {
         BeanWriter out = factory.createWriter("stream2", s);
         try {
             Person person = (Person) in.read();
-            assertEquals(new Integer(25), person.getAge());
+            assertEquals(Integer.valueOf(25), person.getAge());
             out.write(person);
             
             assertFieldError(in, 5, "record", "age", "", "Required field not set");
@@ -105,7 +105,7 @@ public class XmlFieldTest extends XmlParserTest {
             Person person = (Person) in.read();
             assertEquals("Joe", person.getFirstName());
             assertNull(person.getLastName());
-            assertEquals(new Integer(10), person.getAge());
+            assertEquals(Integer.valueOf(10), person.getAge());
             
             person = (Person) in.read();
             assertEquals("John", person.getFirstName());

--- a/test/org/beanio/parser/xml/record/XmlRecordTest.java
+++ b/test/org/beanio/parser/xml/record/XmlRecordTest.java
@@ -55,7 +55,7 @@ public class XmlRecordTest extends XmlParserTest {
             List list = (List) in.read();
             assertEquals("John", list.get(0));
             assertNull(list.get(1));
-            assertEquals(new Integer(22), list.get(2));
+            assertEquals(Integer.valueOf(22), list.get(2));
 
             out.write(list);
             out.close();

--- a/test/org/beanio/stream/CsvRecordParserTest.java
+++ b/test/org/beanio/stream/CsvRecordParserTest.java
@@ -227,7 +227,7 @@ public class CsvRecordParserTest {
     }
 
     @Test
-    public void testMarshal_AlwaysQuote() throws IOException {
+    public void testMarshal_AlwaysQuote() {
         CsvRecordParserFactory factory = new CsvRecordParserFactory();
         factory.setQuote('\'');
         factory.setEscape('\\');

--- a/test/org/beanio/stream/DelimitedRecordParserTest.java
+++ b/test/org/beanio/stream/DelimitedRecordParserTest.java
@@ -38,7 +38,7 @@ public class DelimitedRecordParserTest {
     }
     
     @Test
-    public void testUnmarshal_Basic() throws IOException {
+    public void testUnmarshal_Basic() {
         RecordUnmarshaller unmarshaller = factory.createUnmarshaller();
         String[] actual = (String[]) unmarshaller.unmarshal("1\t2\t33\t444\t");
         
@@ -47,7 +47,7 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testUnmarshal_EscapeDisabled() throws IOException {
+    public void testUnmarshal_EscapeDisabled() {
         factory.setEscape(null);
         
         RecordUnmarshaller unmarshaller = factory.createUnmarshaller();
@@ -57,7 +57,7 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testUnmarshal_EscapeEscape() throws IOException {
+    public void testUnmarshal_EscapeEscape() {
         factory.setEscape('\\');
         
         RecordUnmarshaller unmarshaller = factory.createUnmarshaller();
@@ -67,7 +67,7 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testUnmarshal_EscapeDelimiter() throws IOException {
+    public void testUnmarshal_EscapeDelimiter() {
         factory.setEscape('\\');
         
         RecordUnmarshaller unmarshaller = factory.createUnmarshaller();
@@ -77,7 +77,7 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testUnmarshal_EscapeOther() throws IOException {
+    public void testUnmarshal_EscapeOther() {
         factory.setEscape('\\');
         
         RecordUnmarshaller unmarshaller = factory.createUnmarshaller();
@@ -87,7 +87,7 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testUnmarshal_CustomDelimiter() throws IOException {
+    public void testUnmarshal_CustomDelimiter() {
         factory.setDelimiter(',');
         
         RecordUnmarshaller unmarshaller = factory.createUnmarshaller();
@@ -111,14 +111,14 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testMarshal_DefaultConfiguration() throws IOException {
+    public void testMarshal_DefaultConfiguration() {
         RecordMarshaller marshaller = factory.createMarshaller();
         String record = marshaller.marshal(new String[] { "value1", "value\t2" });
         assertEquals("value1\tvalue\t2", record);
     }
 
     @Test
-    public void testMarshal_CustomDelimiter() throws IOException {
+    public void testMarshal_CustomDelimiter() {
         factory.setDelimiter(',');
         
         RecordMarshaller marshaller = factory.createMarshaller();
@@ -127,7 +127,7 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testMarshal_CustomDelimiterAndEscape() throws IOException {
+    public void testMarshal_CustomDelimiterAndEscape() {
         factory.setDelimiter(',');
         factory.setEscape('\\');
         
@@ -137,14 +137,14 @@ public class DelimitedRecordParserTest {
     }
 
     @Test
-    public void testMarshal_DefaultFactoryConfiguration() throws IOException {
+    public void testMarshal_DefaultFactoryConfiguration() {
         RecordMarshaller marshaller = factory.createMarshaller();
         String record = marshaller.marshal(new String[] { "value1", "value\t2" });
         assertEquals("value1\tvalue\t2", record);
     }
 
     @Test
-    public void testMarshal_CustomFactoryConfiguration() throws IOException {
+    public void testMarshal_CustomFactoryConfiguration() {
         factory.setDelimiter(',');
         factory.setEscape('\\');
         factory.setRecordTerminator("");

--- a/test/org/beanio/stream/JsonReaderTest.java
+++ b/test/org/beanio/stream/JsonReaderTest.java
@@ -73,7 +73,7 @@ public class JsonReaderTest {
         map = in.read();
         assertEquals(int1, map.get("int1"));
         map = in.read();
-        assertEquals(new Integer(10), map.get("int2"));
+        assertEquals(Integer.valueOf(10), map.get("int2"));
         map = in.read();
         assertEquals(long1, map.get("long1"));
 
@@ -126,7 +126,7 @@ public class JsonReaderTest {
         Map object;
 
         Map map = in.read();
-        assertEquals(new Integer(20), map.get("field2"));
+        assertEquals(Integer.valueOf(20), map.get("field2"));
         object = (Map) map.get("o1");
         assertEquals("value1", object.get("field1"));
 
@@ -137,7 +137,7 @@ public class JsonReaderTest {
         map = in.read();
         object = (Map) map.get("o1");
         assertEquals("value1", object.get("field1"));
-        assertEquals(new Integer(10), object.get("field2"));
+        assertEquals(Integer.valueOf(10), object.get("field2"));
 
         assertNull(in.read());
     }
@@ -190,7 +190,7 @@ public class JsonReaderTest {
             "{ \"array\" : [ [10], { \"field\":\"value\" } ]}");
         
         List list = (List) ((List)map.get("array")).get(0);
-        assertEquals(new Integer(10), list.get(0));
+        assertEquals(Integer.valueOf(10), list.get(0));
         
         map = (Map) ((List)map.get("array")).get(1);
         assertEquals("value", map.get("field"));

--- a/test/org/beanio/stream/JsonReaderTest.java
+++ b/test/org/beanio/stream/JsonReaderTest.java
@@ -183,7 +183,7 @@ public class JsonReaderTest {
     
     @Test
     @SuppressWarnings("rawtypes")
-    public void test_mixedArray() throws IOException {
+    public void test_mixedArray() {
         JsonRecordUnmarshaller u = new JsonRecordUnmarshaller();
         
         Map map = u.unmarshal(
@@ -197,49 +197,49 @@ public class JsonReaderTest {
     }
     
     @Test
-    public void test_missingObject() throws IOException {
+    public void test_missingObject() {
         assertError(null, "Expected '{' near position 1");
         assertError("", "Expected '{' near position 1");
         assertError(" ", "Expected '{' near position 1");
     }
     
     @Test
-    public void test_missingQuotes() throws IOException {
+    public void test_missingQuotes() {
         assertError("{ field : \"value\" }", "Expected string or '}' near position 3");
     }
     
     @Test
-    public void test_missingCommaInObject() throws IOException {
+    public void test_missingCommaInObject() {
         assertError("{ \"f1\" : \"value\" \"f2\" : \"value2\" }", "Expected ',' or '}' near position 18");
     }
 
     @Test
-    public void test_missingCommaInArray() throws IOException {
+    public void test_missingCommaInArray() {
         assertError("{ \"array\" : [ 10 20 ] }", "Expected ',' near position 18");
     }
     
     @Test
-    public void test_invalidValue() throws IOException {
+    public void test_invalidValue() {
         assertError("{ \"number\" : a }", "Cannot parse 'a' into a JSON string, number or boolean near position 15");
     }
 
     @Test
-    public void test_missingCloseObject() throws IOException {
+    public void test_missingCloseObject() {
         assertError("{ \"number\" : 10", "Expected ',' or '}' near position 15");
     }
 
     @Test
-    public void test_missingCloseArray() throws IOException {
+    public void test_missingCloseArray() {
         assertError("{ \"number\" : [ 10", "Expected ',' or ']' near position 17");
     }
     
     @Test
-    public void test_missingCloseString() throws IOException {
+    public void test_missingCloseString() {
         assertError("{ \"number", "Expected '\"' near position 9");
     }
     
     @Test
-    public void test_missingColon() throws IOException {
+    public void test_missingColon() {
         assertError("{ \"number\" 10 }", "Expected ':' near position 12");
     }    
     

--- a/test/org/beanio/types/CharacterTypeHandlerTest.java
+++ b/test/org/beanio/types/CharacterTypeHandlerTest.java
@@ -42,7 +42,7 @@ public class CharacterTypeHandlerTest {
     }
     
     @Test
-    public void testFormat() throws TypeConversionException {
+    public void testFormat() {
         CharacterTypeHandler handler = new CharacterTypeHandler();
         assertEquals("V", handler.format(Character.valueOf('V')));
         assertEquals("", handler.format(""));

--- a/test/org/beanio/types/CharacterTypeHandlerTest.java
+++ b/test/org/beanio/types/CharacterTypeHandlerTest.java
@@ -30,7 +30,7 @@ public class CharacterTypeHandlerTest {
     @Test
     public void testParse() throws TypeConversionException {
         CharacterTypeHandler handler = new CharacterTypeHandler();
-        assertEquals(new Character('V'), handler.parse("V"));
+        assertEquals(Character.valueOf('V'), handler.parse("V"));
         assertNull(handler.parse(null));
         assertNull(handler.parse(""));
     }
@@ -44,7 +44,7 @@ public class CharacterTypeHandlerTest {
     @Test
     public void testFormat() throws TypeConversionException {
         CharacterTypeHandler handler = new CharacterTypeHandler();
-        assertEquals("V", handler.format(new Character('V')));
+        assertEquals("V", handler.format(Character.valueOf('V')));
         assertEquals("", handler.format(""));
         assertNull(handler.format(null));
     }

--- a/test/org/beanio/types/XmlBooleanTypeHandlerTest.java
+++ b/test/org/beanio/types/XmlBooleanTypeHandlerTest.java
@@ -41,7 +41,7 @@ public class XmlBooleanTypeHandlerTest {
     }
     
     @Test
-    public void testTextualFormat() throws TypeConversionException {
+    public void testTextualFormat() {
         XmlBooleanTypeHandler handler = new XmlBooleanTypeHandler();
         assertFalse(handler.isNumericFormatEnabled());
         assertNull(handler.format(null));
@@ -50,7 +50,7 @@ public class XmlBooleanTypeHandlerTest {
     }
     
     @Test
-    public void testNumericFormat() throws TypeConversionException {
+    public void testNumericFormat() {
         XmlBooleanTypeHandler handler = new XmlBooleanTypeHandler();
         handler.setNumericFormatEnabled(true);
         assertTrue(handler.isNumericFormatEnabled());

--- a/test/org/beanio/util/IOUtilTest.java
+++ b/test/org/beanio/util/IOUtilTest.java
@@ -31,6 +31,7 @@ public class IOUtilTest {
     @Test
     public void testCloseReader() {
         Reader in = new FilterReader(new StringReader("value")) {
+            @Override
             public void close() throws IOException {
                 throw new IOException();
             }
@@ -42,6 +43,7 @@ public class IOUtilTest {
     @Test
     public void testCloseWriter() {
         Writer out = new StringWriter() {
+            @Override
             public void close() throws IOException {
                 throw new IOException();
             }
@@ -54,6 +56,7 @@ public class IOUtilTest {
     public void testCloseInputStream() {
         byte [] b = new byte[] { 1, 2, 3, 4 };
         InputStream in = new ByteArrayInputStream(b) {
+            @Override
             public void close() throws IOException {
                 throw new IOException();
             }
@@ -65,6 +68,7 @@ public class IOUtilTest {
     @Test
     public void testCloseOutputStream() {
         OutputStream out = new ByteArrayOutputStream() {
+            @Override
             public void close() throws IOException {
                 throw new IOException();
             }


### PR DESCRIPTION
Using `valueOf` methods from `Integer`, `Character` and more are prefereable because uses cache to return an instance.
