### PR TITLE
Added the group order configuration missing from the annotation parser

### DIFF
--- a/src/org/beanio/internal/config/annotation/AnnotationParser.java
+++ b/src/org/beanio/internal/config/annotation/AnnotationParser.java
@@ -422,6 +422,7 @@ public class AnnotationParser {
         GroupConfig gc = new GroupConfig();
         gc.setName(info.name);
         gc.setType(info.propertyName);
+        gc.setOrder(toValue(group.order()));
         gc.setCollection(info.collectionName);
         
         Integer minOccurs = toValue(group.minOccurs());


### PR DESCRIPTION
The annotation configuration was generating errors because it could not detect the order configuration of the groups, as it wasn't set. This is a fix for that bug.