### PR TITLE
Fix DecimalFormat thread issue in NumberTypeHandler

### DIFF
--- a/test/org/beanio/parser/fixedlength/MyRec.java
+++ b/test/org/beanio/parser/fixedlength/MyRec.java
@@ -1,0 +1,45 @@
+package org.beanio.parser.fixedlength;
+
+import java.io.Serializable;
+
+public class MyRec implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String string;
+    private long num;
+
+    public String getString() {
+        return string;
+    }
+
+    public void setString(String string) {
+        this.string = string;
+    }
+
+    public long getNum() {
+        return num;
+    }
+
+    public void setNum(long num) {
+        this.num = num;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MyRec myRec = (MyRec) o;
+
+        if (num != myRec.num) return false;
+        return string.equals(myRec.string);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = string.hashCode();
+        result = 31 * result + (int) (num ^ (num >>> 32));
+        return result;
+    }
+}

--- a/test/org/beanio/parser/fixedlength/fixedlength.xml
+++ b/test/org/beanio/parser/fixedlength/fixedlength.xml
@@ -104,4 +104,11 @@
     </record>
   </stream>
 
+  <stream name="f9" format="fixedlength">
+    <record name="id" order="1" minOccurs="1" maxOccurs="1" class="org.beanio.parser.fixedlength.MyRec">
+      <field name="string" length="1"/>
+      <field name="num" type="long" length="10" format="##########" justify="right" padding="0"/>
+    </record>
+  </stream>
+
 </beanio>


### PR DESCRIPTION
This fixes an issue where DecimalFormat will spit out Exceptions when hit simultaneously from several threads. The issue seems similar to #10. The attached test should trigger Exceptions if the changes in NumberTypeHandler are removed.