### PR TITLE
Fixed typo in format attribute for delimited stream

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -761,7 +761,7 @@ for the delimited stream 's1':</p>
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.beanio.org/2012/03 http://www.beanio.org/2012/03/mapping.xsd"&gt;
 
-  &lt;stream name="s1" format="delmiited"&gt;
+  &lt;stream name="s1" format="delimited"&gt;
     <span class="highlight">&lt;parser&gt;
       &lt;property name="delimiter" value="|" /&gt;
     &lt;/parser&gt;</span>


### PR DESCRIPTION
Section 4, second example of a stream (name="s1") had a typo in the format attribute, changed from 'format="delmiited"' to 'format="delimited'